### PR TITLE
1.0.1

### DIFF
--- a/DDM-OS-Reminder End-user Message.zsh
+++ b/DDM-OS-Reminder End-user Message.zsh
@@ -14,7 +14,7 @@
 #
 # HISTORY
 #
-# Version 1.0.0, 14-Oct-2025, Dan K. Snelson (@dan-snelson)
+# Version 1.0.1, 14-Oct-2025, Dan K. Snelson (@dan-snelson)
 #   - First "official" release (thanks for the testing and feedback, @TechTrekkie!)
 #
 ####################################################################################################
@@ -30,7 +30,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local:/usr/local/bin
 
 # Script Version
-scriptVersion="1.0.0"
+scriptVersion="1.0.1"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"
@@ -241,7 +241,6 @@ function displayDialogWindow() {
         --button1text "${button1text}" \
         --button2text "${button2text}" \
         --infobuttontext "${infobuttontext}" \
-        --infobuttonaction "${infobuttonaction}" \
         --messagefont "size=14" \
         --helpmessage "${helpmessage}" \
         --helpimage "${helpimage}" \
@@ -270,6 +269,8 @@ function displayDialogWindow() {
 
         3)  ## Process exit code 3 scenario here
             notice "User clicked ${infobuttontext}"
+            echo "blurscreen: disable" >> /var/tmp/dialog.log
+            open "${infobuttonaction}"
             ;;
 
         4)  ## Process exit code 4 scenario here


### PR DESCRIPTION
Removed infobuttonaction and utilized exit code 3 to disable blurscreen and open the URL set for infobuttonaction.
This will close the dialog and launch the URL for infobuttonaction when the Info button is clicked. Previously, using infobuttonaction when blurscreen was enabled would prevent the web browser from appearing until the dialog was closd after the fact. 