### PR TITLE
Use --infobuttonaction and prevent dialog from closing on info click

### DIFF
--- a/DDM-OS-Reminder End-user Message.zsh
+++ b/DDM-OS-Reminder End-user Message.zsh
@@ -356,6 +356,7 @@ function displayReminderDialog() {
         --button1text "${button1text}" \
         --button2text "${button2text}" \
         --infobuttontext "${infobuttontext}" \
+        --infobuttonaction "${infobuttonaction}" \
         --messagefont "size=14" \
         --helpmessage "${helpmessage}" \
         --helpimage "${helpimage}" \


### PR DESCRIPTION
This change updates the default swiftDialog behaviour so that clicking the “KB” button opens the URL without exiting the dialog window. This provides a better user experience for DDM OS reminders, letting the user read the update details and then continue with the required OS update action.