### PR TITLE
Pull Request for Feature Request: Excessive Uptime Warning #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Changelog
 
-### Version 2.1.0b2 (09-Dec-2025)
+### Version 2.1.0b4 (09-Dec-2025)
 - Added ability to use `titleMessageUpdateOrUpgrade:l` (Pull Request #26; thanks, @maxsundellacne!)
 - Added logic to hide `button2` based on `DaysBeforeDeadlineHidingButton2` (Pull Request #27; thanks, @maxsundellacne!)
 - Refactored `resetConfiguration` function to avoid errors when attempting to `chmod` non-existent files
+- Added warning for excessive uptime (configurable via `DaysOfExcessiveUptimeWarning` variable; #28)
 
 ### Version 2.0.0 (06-Dec-2025)
 - Reorganized script structure for (hopefully) improved clarity

--- a/Resources/createPlist.zsh
+++ b/Resources/createPlist.zsh
@@ -83,6 +83,7 @@ scriptLog=$(awk -F'"' '/^scriptLog=/{print $2}' "$SOURCE_SCRIPT")
 daysBeforeDeadlineDisplayReminder=$(awk -F'"' '/^daysBeforeDeadlineDisplayReminder=/{print $2}' "$SOURCE_SCRIPT")
 daysBeforeDeadlineBlurscreen=$(awk -F'"' '/^daysBeforeDeadlineBlurscreen=/{print $2}' "$SOURCE_SCRIPT")
 daysBeforeDeadlineHidingButton2=$(awk -F'"' '/^daysBeforeDeadlineHidingButton2=/{print $2}' "$SOURCE_SCRIPT")
+daysOfExcessiveUptimeWarning=$(awk -F'"' '/^daysOfExcessiveUptimeWarning=/{print $2}' "$SOURCE_SCRIPT")
 meetingDelay=$(awk -F'"' '/^meetingDelay=/{print $2}' "$SOURCE_SCRIPT")
 dateFormatDeadlineHumanReadable=$(awk -F'"' '/^dateFormatDeadlineHumanReadable=/{print $2}' "$SOURCE_SCRIPT")
 swapOverlayAndLogo_raw=$(awk -F'"' '/^swapOverlayAndLogo=/{print $2}' "$SOURCE_SCRIPT")
@@ -96,6 +97,7 @@ esac
 # Extract all defaults
 # ─────────────────────────────────────────────────────────────
 defaultTitle=$(extract_default defaultTitle)
+defaultExcessiveUptimeWarningMessage=$(extract_default defaultExcessiveUptimeWarningMessage)
 defaultMessage=$(extract_default defaultMessage)
 defaultInfobox=$(extract_default defaultInfobox)
 defaultHelpmessage=$(extract_default defaultHelpmessage)
@@ -124,6 +126,7 @@ resolvedInfobuttontext="$defaultSupportKB"
 # Process strings
 # ---------------------------------------------------------------------
 title_xml=$(process "$defaultTitle")
+excessiveUptimeWarningMessage_xml=$(process "$defaultExcessiveUptimeWarningMessage")
 message_xml=$(process "$defaultMessage")
 infobox_xml=$(process "$defaultInfobox")
 helpmessage_xml=$(process "$defaultHelpmessage")
@@ -171,6 +174,8 @@ cat > "$OUTPUT_PLIST_FILE" <<EOF
     <integer>${daysBeforeDeadlineBlurscreen}</integer>
     <key>DaysBeforeDeadlineHidingButton2</key>
     <integer>${daysBeforeDeadlineHidingButton2}</integer>
+    <key>DaysOfExcessiveUptimeWarning</key>
+    <integer>${daysOfExcessiveUptimeWarning}</integer>
     <key>MeetingDelay</key>
     <integer>${meetingDelay}</integer>
 
@@ -207,6 +212,8 @@ cat > "$OUTPUT_PLIST_FILE" <<EOF
     <string>${button2text_xml}</string>
     <key>InfoButtonText</key>
     <string>${infobuttontext_xml}</string>
+    <key>ExcessiveUptimeWarningMessage</key>
+    <string>${excessiveUptimeWarningMessage_xml}</string>
     <key>Message</key>
     <string>${message_xml}</string>
 
@@ -254,6 +261,8 @@ cat <<EOF > "${OUTPUT_MOBILECONFIG_FILE}"
                                 <integer>${daysBeforeDeadlineBlurscreen}</integer>
                                 <key>DaysBeforeDeadlineHidingButton2</key>
                                 <integer>${daysBeforeDeadlineHidingButton2}</integer>
+                                <key>DaysOfExcessiveUptimeWarning</key>
+                                <integer>${daysOfExcessiveUptimeWarning}</integer>
                                 <key>MeetingDelay</key>
                                 <integer>${meetingDelay}</integer>
                                 <key>OrganizationOverlayIconURL</key>
@@ -284,6 +293,8 @@ cat <<EOF > "${OUTPUT_MOBILECONFIG_FILE}"
                                 <string>${button2text_xml}</string>
                                 <key>InfoButtonText</key>
                                 <string>${infobuttontext_xml}</string>
+                                <key>ExcessiveUptimeWarningMessage</key>
+                                <string>${excessiveUptimeWarningMessage_xml}</string>
                                 <key>Message</key>
                                 <string>${message_xml}</string>
                                 <key>InfoBox</key>

--- a/launchDaemonManagement.zsh
+++ b/launchDaemonManagement.zsh
@@ -21,10 +21,11 @@
 #
 # HISTORY
 #
-# Version 2.1.0b3, 09-Dec-2025, Dan K. Snelson (@dan-snelson)
+# Version 2.1.0b4, 09-Dec-2025, Dan K. Snelson (@dan-snelson)
 #   - Added ability to use `titleMessageUpdateOrUpgrade:l` (Pull Request #26; thanks, @maxsundellacne!)
 #   - Added logic to hide `button2` based on `DaysBeforeDeadlineHidingButton2` (Pull Request #27; thanks, @maxsundellacne!)
 #   - Refactored `resetConfiguration` function to avoid errors when attempting to `chmod` non-existent files
+#   - Added warning for excessive uptime (configurable via `DaysOfExcessiveUptimeWarning` variable; #28)
 #
 ####################################################################################################
 
@@ -39,7 +40,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local:/usr/local/bin
 
 # Script Version
-scriptVersion="2.1.0b3"
+scriptVersion="2.1.0b4"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"

--- a/org.churchofjesuschrist.dorm.plist
+++ b/org.churchofjesuschrist.dorm.plist
@@ -3,66 +3,72 @@
 <plist version="1.0">
 <dict>
 
-	<!-- Version: 2.1.0b2 -->
+    <!-- Preferences Domain: org.churchofjesuschrist.dorm -->
+    <!-- Version: 2.1.0b4 -->
+    <!-- Generated on: 2025-12-09-203605 -->
 
-	<!-- Logging -->
-	<key>ScriptLog</key>
-	<string>/var/log/org.churchofjesuschrist.log</string>
+    <!-- Logging -->
+    <key>ScriptLog</key>
+    <string>/var/log/org.churchofjesuschrist.log</string>
 
-	<!-- Reminder timing -->
-	<key>DaysBeforeDeadlineDisplayReminder</key>
-	<integer>14</integer>
-	<key>DaysBeforeDeadlineBlurscreen</key>
-	<integer>3</integer>
-	<key>DaysBeforeDeadlineHidingButton2</key>
-	<integer>1</integer>
-	<key>MeetingDelay</key>
-	<integer>75</integer>
+    <!-- Reminder timing -->
+    <key>DaysBeforeDeadlineDisplayReminder</key>
+    <integer>14</integer>
+    <key>DaysBeforeDeadlineBlurscreen</key>
+    <integer>3</integer>
+    <key>DaysBeforeDeadlineHidingButton2</key>
+    <integer>1</integer>
+    <key>DaysOfExcessiveUptimeWarning</key>
+    <integer>7</integer>
+    <key>MeetingDelay</key>
+    <integer>75</integer>
 
-	<!-- Branding -->
-	<key>OrganizationOverlayIconURL</key>
-	<string>https://usw2.ics.services.jamfcloud.com/icon/hash_4804203ac36cbd7c83607487f4719bd4707f2e283500f54428153af17da082e2</string>
-	<key>SwapOverlayAndLogo</key>
-	<false/>
-	<key>DateFormatDeadlineHumanReadable</key>
-	<string>+%a, %d-%b-%Y, %-l:%M %p</string>
+    <!-- Branding -->
+    <key>OrganizationOverlayIconURL</key>
+    <string>https://usw2.ics.services.jamfcloud.com/icon/hash_4804203ac36cbd7c83607487f4719bd4707f2e283500f54428153af17da082e2</string>
+    <key>SwapOverlayAndLogo</key>
+    <false/>
+    <key>DateFormatDeadlineHumanReadable</key>
+    <string>+%a, %d-%b-%Y, %-l:%M %p</string>
 
-	<!-- Support block -->
-	<key>SupportTeamName</key>
-	<string>IT Support</string>
-	<key>SupportTeamPhone</key>
-	<string>+1 (801) 555-1212</string>
-	<key>SupportTeamEmail</key>
-	<string>rescue@domain.org</string>
-	<key>SupportTeamWebsite</key>
-	<string>https://support.domain.org</string>
-	<key>SupportKB</key>
-	<string>KB8675309</string>
-	<key>InfoButtonAction</key>
-	<string>https://servicenow.domain.org/support?id=kb_article_view&amp;sysparm_article=KB8675309</string>
-	<key>SupportKBURL</key>
-	<string>[KB8675309](https://servicenow.domain.org/support?id=kb_article_view&amp;sysparm_article=KB8675309)</string>
+    <!-- Support block -->
+    <key>SupportTeamName</key>
+    <string>IT Support</string>
+    <key>SupportTeamPhone</key>
+    <string>+1 (801) 555-1212</string>
+    <key>SupportTeamEmail</key>
+    <string>rescue@domain.org</string>
+    <key>SupportTeamWebsite</key>
+    <string>https://support.domain.org</string>
+    <key>SupportKB</key>
+    <string>108382</string>
+    <key>InfoButtonAction</key>
+    <string>https://support.apple.com/108382</string>
+    <key>SupportKBURL</key>
+    <string>[108382](https://support.apple.com/108382)</string>
 
-	<!-- Dialog text -->
-	<key>Title</key>
-	<string>macOS {titleMessageUpdateOrUpgrade} Required</string>
-	<key>Button1Text</key>
-	<string>Open Software Update</string>
-	<key>Button2Text</key>
-	<string>Remind Me Later</string>
-	<key>InfoButtonText</key>
-	<string>KB8675309</string>
-	<key>Message</key>
-	<string>**A required macOS {titleMessageUpdateOrUpgrade:l} is now available**&lt;br&gt;---&lt;br&gt;Happy {weekday}, {loggedInUserFirstname}!&lt;br&gt;&lt;br&gt;Please {titleMessageUpdateOrUpgrade:l} to macOS **{ddmVersionString}** to ensure your Mac remains secure and compliant with organizational policies.&lt;br&gt;&lt;br&gt;To perform the {titleMessageUpdateOrUpgrade:l} now, click **{button1text}**, review the on-screen instructions, then click **{softwareUpdateButtonText}**.&lt;br&gt;&lt;br&gt;If you are unable to perform this {titleMessageUpdateOrUpgrade:l} now, click **{button2text}** to be reminded again later.&lt;br&gt;&lt;br&gt;However, your device **will automatically restart and {titleMessageUpdateOrUpgrade:l}** on **{ddmEnforcedInstallDateHumanReadable}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline.&lt;br&gt;&lt;br&gt;For assistance, please contact **{supportTeamName}** by clicking the (?) button in the bottom, right-hand corner.</string>
+    <!-- Dialog text -->
+    <key>Title</key>
+    <string>macOS {titleMessageUpdateOrUpgrade} Required</string>
+    <key>Button1Text</key>
+    <string>Open Software Update</string>
+    <key>Button2Text</key>
+    <string>Remind Me Later</string>
+    <key>InfoButtonText</key>
+    <string>108382</string>
+    <key>ExcessiveUptimeWarningMessage</key>
+    <string>&lt;br&gt;&lt;br&gt;**Note:** Your Mac has been powered-on for **{uptimeHumanReadable}**. For more reliable results, please manually restart your Mac before proceeding.</string>
+    <key>Message</key>
+    <string>**A required macOS {titleMessageUpdateOrUpgrade:l} is now available**&lt;br&gt;&lt;br&gt;Happy {weekday}, {loggedInUserFirstname}!&lt;br&gt;&lt;br&gt;Please {titleMessageUpdateOrUpgrade:l} to macOS **{ddmVersionString}** to ensure your Mac remains secure and compliant with organizational policies.&lt;br&gt;&lt;br&gt;To perform the {titleMessageUpdateOrUpgrade:l} now, click **{button1text}**, review the on-screen instructions, then click **{softwareUpdateButtonText}**.&lt;br&gt;&lt;br&gt;If you are unable to perform this {titleMessageUpdateOrUpgrade:l} now, click **{button2text}** to be reminded again later.&lt;br&gt;&lt;br&gt;However, your device **will automatically restart and {titleMessageUpdateOrUpgrade:l}** on **{ddmEnforcedInstallDateHumanReadable}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline.{excessiveUptimeWarningMessage}&lt;br&gt;&lt;br&gt;For assistance, please contact **{supportTeamName}** by clicking the (?) button in the bottom, right-hand corner.</string>
 
-	<!-- Infobox -->
-	<key>InfoBox</key>
-	<string>**Current:** {installedmacOSVersion}&lt;br&gt;&lt;br&gt;**Required:** {ddmVersionString}&lt;br&gt;&lt;br&gt;**Deadline:** {ddmVersionStringDeadlineHumanReadable}&lt;br&gt;&lt;br&gt;**Day(s) Remaining:** {ddmVersionStringDaysRemaining}</string>
+    <!-- Infobox -->
+    <key>InfoBox</key>
+    <string>**Current:** {installedmacOSVersion}&lt;br&gt;&lt;br&gt;**Required:** {ddmVersionString}&lt;br&gt;&lt;br&gt;**Deadline:** {ddmVersionStringDeadlineHumanReadable}&lt;br&gt;&lt;br&gt;**Day(s) Remaining:** {ddmVersionStringDaysRemaining}&lt;br&gt;&lt;br&gt;**Last Restart:** {uptimeHumanReadable}</string>
 
-	<!-- Help section -->
-	<key>HelpMessage</key>
-	<string>For assistance, please contact: **{supportTeamName}**&lt;br&gt;- **Telephone:** {supportTeamPhone}&lt;br&gt;- **Email:** {supportTeamEmail}&lt;br&gt;- **Website:** {supportTeamWebsite}&lt;br&gt;- **Knowledge Base Article:** {supportKBURL}&lt;br&gt;&lt;br&gt;**User Information:**&lt;br&gt;- **Full Name:** {userfullname}&lt;br&gt;- **User Name:** {username}&lt;br&gt;&lt;br&gt;**Computer Information:**&lt;br&gt;- **Computer Name:** {computername}&lt;br&gt;- **Serial Number:** {serialnumber}&lt;br&gt;- **macOS:** {osversion}&lt;br&gt;&lt;br&gt;**Script Information:**&lt;br&gt;- **Dialog:** {dialogVersion}&lt;br&gt;- **Script:** {scriptVersion}&lt;br&gt;</string>
-	<key>HelpImage</key>
-	<string>qr={infobuttonaction}</string>
+    <!-- Help section -->
+    <key>HelpMessage</key>
+    <string>For assistance, please contact: **{supportTeamName}**&lt;br&gt;- **Telephone:** {supportTeamPhone}&lt;br&gt;- **Email:** {supportTeamEmail}&lt;br&gt;- **Website:** {supportTeamWebsite}&lt;br&gt;- **Knowledge Base Article:** {supportKBURL}&lt;br&gt;&lt;br&gt;**User Information:**&lt;br&gt;- **Full Name:** {userfullname}&lt;br&gt;- **User Name:** {username}&lt;br&gt;&lt;br&gt;**Computer Information:**&lt;br&gt;- **Computer Name:** {computername}&lt;br&gt;- **Serial Number:** {serialnumber}&lt;br&gt;- **macOS:** {osversion}&lt;br&gt;&lt;br&gt;**Script Information:**&lt;br&gt;- **Dialog:** {dialogVersion}&lt;br&gt;- **Script:** {scriptVersion}&lt;br&gt;</string>
+    <key>HelpImage</key>
+    <string>qr={infobuttonaction}</string>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses #28

`infobox` now includes: `**Last Restart:** ${uptimeHumanReadable}`

---

When the Mac's uptime is greater than `DaysOfExcessiveUptimeWarning`, the `ExcessiveUptimeWarningMessage` will be displayed:
> **Note:** Your Mac has been powered-on for **${uptimeHumanReadable}**. For more reliable results, please manually restart your Mac before proceeding.

In the following example, the test Mac had `4` days of uptime, so: `daysOfExcessiveUptimeWarning="3"` (but its default is `7`).

<img width="912" height="744" alt="Screenshot 2025-12-09 at 7 45 26 PM" src="https://github.com/user-attachments/assets/fe2ebc8b-a5ec-465b-afab-2c982f72c8fd" />

---

When the Mac's uptime is less than `DaysOfExcessiveUptimeWarning`, `excessiveUptimeWarningMessage` is `unset`:

<img width="912" height="744" alt="Screenshot 2025-12-09 at 7 46 00 PM" src="https://github.com/user-attachments/assets/2642e6e4-fdc1-4244-a4a1-c4a15be05f95" />