### PR TITLE
Replace defaults read with PlistBuddy for prefs

### DIFF
--- a/reminderDialog.zsh
+++ b/reminderDialog.zsh
@@ -348,13 +348,15 @@ function loadPreferenceOverrides() {
         # Read managed value
         local managedValue=""
         if [[ "${hasManagedPrefs}" == "true" ]]; then
-            managedValue=$(defaults read "${managedPreferencesPlist}" "${plistKey}" 2>/dev/null)
+            managedValue=$(/usr/libexec/PlistBuddy -c "Print :${plistKey}" "${managedPreferencesPlist}.plist" 2>/dev/null)
+
         fi
         
         # Read local value
         local localValue=""
         if [[ "${hasLocalPrefs}" == "true" ]]; then
-            localValue=$(defaults read "${localPreferencesPlist}" "${plistKey}" 2>/dev/null)
+            localValue=$(/usr/libexec/PlistBuddy -c "Print :${plistKey}" "${localPreferencesPlist}.plist" 2>/dev/null)
+
         fi
         
         # Apply the preference based on type


### PR DESCRIPTION
## Problem
`defaults read` corrupts UTF-8 characters when reading plist values, displaying accented characters as octal codes (e.g., `à` becomes `\340`).

This affects any localization using non-ASCII characters (French, German, Spanish, etc.).

## Root cause
The macOS `defaults read` command doesn't properly handle UTF-8 encoding when outputting string values.

## Proof
```bash
# Plist file is correct:
cat /Library/Preferences/ch.hepl.dorm.plist
# Shows: Mise à jour 

# defaults read corrupts it:
defaults read /Library/Preferences/ch.hepl.dorm Title
# Shows: Mise \340 jour 

# PlistBuddy works perfectly:
/usr/libexec/PlistBuddy -c "Print :Title" /Library/Preferences/ch.hepl.dorm.plist
# Shows: Mise à jour 
```

## Fix
Replace `defaults read` with `/usr/libexec/PlistBuddy` in `loadPreferenceOverrides()` for both managed and local preference reads.

Tested on macOS 26 with French localization. 