### PR TITLE
Add repo-specific security scan workflow and security policy

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,4 +1,4 @@
-# Protects DDM OS Reminder from common vulnerabilities with Semgrep, Gitleaks, zsh syntax validation, and ShellCheck. Semgrep scans the full repository, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content, then uploads findings to GitHub code scanning. Gitleaks scans the full git history for potential secrets. Tracked zsh files are validated with zsh -n, including main scripts, zsh helpers in Resources/, and tracked assembled zsh artifacts in Artifacts/. Tracked sh/bash files are checked with ShellCheck when present. ShellCheck treats SC1090/SC1091 as informational due to common dynamic sourcing patterns in shell projects.
+# Protects DDM OS Reminder from common vulnerabilities with Semgrep, Gitleaks, zsh syntax validation, and ShellCheck. Semgrep scans the full repository, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content, then uploads findings to GitHub code scanning. Gitleaks scans the full git history for potential secrets. Tracked zsh files are validated with zsh -n, including main scripts, zsh helpers in Resources/, and tracked assembled zsh artifacts in Artifacts/. Tracked shell-script files with bash/dash/ksh/sh shebangs are checked with ShellCheck when present. ShellCheck treats SC1090/SC1091 as informational due to common dynamic sourcing patterns in shell projects.
 
 name: Security Scan
 
@@ -170,7 +170,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Check Out Repository
         # Fetch full history so Gitleaks can scan past commits on protected branches.
@@ -182,11 +181,7 @@ jobs:
         id: gitleaks_mode
         shell: bash
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name || '' }}" != "${GITHUB_REPOSITORY}" ]]; then
-            echo "enable_comments=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "enable_comments=true" >> "${GITHUB_OUTPUT}"
-          fi
+          echo "enable_comments=false" >> "${GITHUB_OUTPUT}"
 
       - name: Run Gitleaks (Blocking)
         id: gitleaks_scan
@@ -214,9 +209,7 @@ jobs:
               echo "✅ No leaks found"
               echo
               echo "Coverage: full git history for repository content, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
-              if [[ "${{ steps.gitleaks_mode.outputs.enable_comments }}" == "false" ]]; then
-                echo "PR comments were disabled for this fork pull request."
-              fi
+              echo "PR comments are disabled in this workflow to keep Gitleaks read-only."
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
@@ -227,9 +220,7 @@ jobs:
             echo "❌ Potential secrets detected or Gitleaks execution failed."
             echo
             echo "Coverage: full git history for repository content, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
-            if [[ "${{ steps.gitleaks_mode.outputs.enable_comments }}" == "false" ]]; then
-              echo "PR comments were disabled for this fork pull request."
-            fi
+            echo "PR comments are disabled in this workflow to keep Gitleaks read-only."
             echo "Tune accepted false positives with \`.gitleaks.toml\` or \`.gitleaksignore\` if needed."
           } >> "${GITHUB_STEP_SUMMARY}"
           exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,540 @@
+# Protects DDM OS Reminder from common vulnerabilities with Semgrep, Gitleaks, zsh syntax validation, and ShellCheck. Semgrep scans the full repository, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content, then uploads findings to GitHub code scanning. Gitleaks scans the full git history for potential secrets. Tracked zsh files are validated with zsh -n, including main scripts, zsh helpers in Resources/, and tracked assembled zsh artifacts in Artifacts/. Tracked sh/bash files are checked with ShellCheck when present. ShellCheck treats SC1090/SC1091 as informational due to common dynamic sourcing patterns in shell projects.
+
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
+  schedule:
+    - cron: '43 2 * * 3'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: security-scan-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      # Uncomment for private/internal repos if GitHub code scanning upload requires it.
+      # actions: read
+    env:
+      SEMGREP_RULES: >-
+        --config p/r2c-security-audit
+        --config p/ci
+        --config p/secrets
+    steps:
+      - name: Check Out Repository
+        # Fetch full history so diff-aware scans and code scanning uploads have the right context.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Semgrep CLI
+        # Use the CLI directly so the blocking scan and SARIF export come from the same execution path.
+        run: python3 -m pip install --upgrade semgrep
+
+      - name: Run Semgrep CLI (Blocking + SARIF)
+        id: semgrep_sarif
+        # Always attempt SARIF generation so findings can land in the Security tab even when blocking scan fails.
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+
+          baseline_args=()
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${{ github.event.pull_request.base.sha }}" ]]; then
+            baseline_args+=(--baseline-commit "${{ github.event.pull_request.base.sha }}")
+          fi
+
+          semgrep scan \
+            --error \
+            --sarif \
+            --output semgrep.sarif \
+            ${SEMGREP_RULES} \
+            "${baseline_args[@]}"
+
+      - name: Normalize SARIF For GitHub
+        id: normalize_sarif
+        if: hashFiles('semgrep.sarif') != ''
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          sarif_path = Path("semgrep.sarif")
+          data = json.loads(sarif_path.read_text())
+
+          severity_map = {
+              "critical": "9.0",
+              "high": "8.9",
+              "medium": "6.9",
+              "low": "3.9",
+              "info": "0.1",
+              "warning": "5.0",
+              "error": "8.0",
+          }
+
+          for run in data.get("runs", []):
+              for rule in run.get("tool", {}).get("driver", {}).get("rules", []):
+                  properties = rule.setdefault("properties", {})
+                  value = properties.get("security-severity")
+                  if isinstance(value, str) and not value.replace(".", "", 1).isdigit():
+                      properties["security-severity"] = severity_map.get(value.lower(), "5.0")
+
+              for result in run.get("results", []):
+                  properties = result.setdefault("properties", {})
+                  value = properties.get("security-severity")
+                  if isinstance(value, str) and not value.replace(".", "", 1).isdigit():
+                      properties["security-severity"] = severity_map.get(value.lower(), "5.0")
+
+          sarif_path.write_text(json.dumps(data))
+          PY
+
+      - name: Upload Semgrep Findings To Code Scanning
+        id: upload_sarif
+        if: hashFiles('semgrep.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        # Repo Actions permissions must allow SARIF uploads or this step will fail even with security-events: write.
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      - name: Finalize Semgrep Result
+        if: success() || failure()
+        shell: bash
+        run: |
+          sarif_outcome="${{ steps.semgrep_sarif.outcome }}"
+          upload_outcome="${{ steps.upload_sarif.outcome }}"
+          trusted_upload_context="${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}"
+
+          if [[ "${sarif_outcome}" == "success" ]]; then
+            if [[ "${trusted_upload_context}" == "true" && "${upload_outcome}" != "success" ]]; then
+              {
+                echo "### Semgrep"
+                echo
+                echo "❌ Semgrep scan passed, but SARIF upload needs attention."
+                echo
+                echo "Coverage: full repository scan, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
+                echo "SARIF upload did not complete in a trusted context. Check repository Actions permissions and upload step logs."
+              } >> "${GITHUB_STEP_SUMMARY}"
+              exit 1
+            fi
+
+            {
+              echo "### Semgrep"
+              echo
+              echo "✅ No issues found"
+              echo
+              echo "Coverage: full repository scan, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
+              if [[ "${trusted_upload_context}" == "true" ]]; then
+                echo "SARIF uploaded to GitHub code scanning successfully."
+              else
+                echo "SARIF upload skipped for fork pull requests because code scanning write permissions are not available."
+              fi
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "### Semgrep"
+            echo
+            echo "❌ Findings detected or Semgrep execution needs attention."
+            echo
+            echo "Coverage: full repository scan, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
+            if [[ "${upload_outcome}" == "success" ]]; then
+              echo "Findings were uploaded to GitHub code scanning."
+            elif [[ "${trusted_upload_context}" != "true" ]]; then
+              echo "SARIF upload was skipped for a fork pull request."
+            else
+              echo "SARIF upload did not complete. Check repository Actions permissions and Semgrep output."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check Out Repository
+        # Fetch full history so Gitleaks can scan past commits on protected branches.
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine Gitleaks Comment Mode
+        id: gitleaks_mode
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name || '' }}" != "${GITHUB_REPOSITORY}" ]]; then
+            echo "enable_comments=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "enable_comments=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Run Gitleaks (Blocking)
+        id: gitleaks_scan
+        continue-on-error: true
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: ${{ steps.gitleaks_mode.outputs.enable_comments }}
+          GITLEAKS_ENABLE_SUMMARY: "true"
+          # Future tuning examples:
+          # GITLEAKS_CONFIG: .gitleaks.toml
+          # Use `.gitleaksignore` or allowlists for accepted false positives.
+          # Org-owned repos also need GITLEAKS_LICENSE in repository or organization secrets.
+
+      - name: Finalize Gitleaks Result
+        if: success() || failure()
+        shell: bash
+        run: |
+          scan_outcome="${{ steps.gitleaks_scan.outcome }}"
+
+          if [[ "${scan_outcome}" == "success" ]]; then
+            {
+              echo "### Gitleaks"
+              echo
+              echo "✅ No leaks found"
+              echo
+              echo "Coverage: full git history for repository content, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
+              if [[ "${{ steps.gitleaks_mode.outputs.enable_comments }}" == "false" ]]; then
+                echo "PR comments were disabled for this fork pull request."
+              fi
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "### Gitleaks"
+            echo
+            echo "❌ Potential secrets detected or Gitleaks execution failed."
+            echo
+            echo "Coverage: full git history for repository content, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, Resources/, Artifacts/, and other tracked content."
+            if [[ "${{ steps.gitleaks_mode.outputs.enable_comments }}" == "false" ]]; then
+              echo "PR comments were disabled for this fork pull request."
+            fi
+            echo "Tune accepted false positives with \`.gitleaks.toml\` or \`.gitleaksignore\` if needed."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
+  zsh_syntax:
+    name: Zsh Syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Zsh
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes zsh
+
+      - name: Collect Zsh Targets
+        id: collect_targets
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import re
+          import subprocess
+          from pathlib import Path
+
+          shebang_pattern = re.compile(r"^#!.*(?:/| )zsh(?:\s|$)")
+          output_path = Path("zsh-targets.txt")
+          targets = []
+
+          files = subprocess.check_output(
+              ["git", "ls-files", "*.zsh", "*.sh", "*.bash"],
+              text=True,
+          ).splitlines()
+
+          for file_name in files:
+              file_path = Path(file_name)
+              first_line = file_path.open(encoding="utf-8", errors="ignore").readline().strip()
+              if file_name.endswith(".zsh") or shebang_pattern.search(first_line):
+                  targets.append(file_name)
+
+          output_path.write_text("".join(f"{target}\n" for target in targets))
+          PY
+          count="$(grep -c '.' zsh-targets.txt || true)"
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run zsh -n
+        id: zsh_syntax
+        if: steps.collect_targets.outputs.count != '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          status=0
+
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            if ! zsh -n "${file}"; then
+              status=1
+            fi
+          done < zsh-targets.txt
+
+          set -e
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+
+      - name: Finalize Zsh Syntax Result
+        if: success() || failure()
+        shell: bash
+        run: |
+          target_count="${{ steps.collect_targets.outputs.count }}"
+          syntax_status="${{ steps.zsh_syntax.outputs.status }}"
+
+          if [[ "${target_count}" == "0" ]]; then
+            {
+              echo "### Zsh Syntax"
+              echo
+              echo "✅ No tracked zsh files matched the scan patterns."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "### Zsh Syntax"
+            echo
+            echo "- Files scanned: ${target_count}"
+            echo "- Coverage: tracked zsh files and zsh-shebang helpers, including reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, zsh helpers in Resources/, and tracked assembled zsh artifacts in Artifacts/."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${syntax_status}" == "0" ]]; then
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "✅ All zsh files passed \`zsh -n\`" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "❌ zsh syntax errors found" >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Collect Shell Targets
+        id: collect_targets
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import re
+          import subprocess
+          from pathlib import Path
+
+          shebang_pattern = re.compile(r"^#!.*(?:/| )(?:bash|dash|ksh|sh)(?:\s|$)")
+          output_path = Path("shellcheck-targets.txt")
+          targets = []
+
+          files = subprocess.check_output(
+              ["git", "ls-files", "*.sh", "*.bash"],
+              text=True,
+          ).splitlines()
+
+          for file_name in files:
+              file_path = Path(file_name)
+              first_line = file_path.open(encoding="utf-8", errors="ignore").readline().strip()
+              if shebang_pattern.search(first_line):
+                  targets.append(file_name)
+
+          output_path.write_text("".join(f"{target}\n" for target in targets))
+          PY
+          count="$(grep -c '.' shellcheck-targets.txt || true)"
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install ShellCheck
+        if: steps.collect_targets.outputs.count != '0'
+        # Native ShellCheck keeps permissions minimal while still producing strong annotations.
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes shellcheck
+
+      - name: Run Blocking ShellCheck Pass
+        id: shellcheck_blocking
+        if: steps.collect_targets.outputs.count != '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          mapfile -t shell_files < shellcheck-targets.txt
+
+          set +e
+          shellcheck --severity=style --format=gcc -e SC1090,SC1091 "${shell_files[@]}" > shellcheck-blocking.gcc
+          status=$?
+          set -e
+
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          def escape_workflow_command(value):
+              return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+          pattern = re.compile(r"^(.*?):(\d+):(\d+):\s+([a-z]+):\s+(.*)$")
+          for line in Path("shellcheck-blocking.gcc").read_text().splitlines():
+              match = pattern.match(line)
+              if not match:
+                  print(line)
+                  continue
+              file_path, line_no, col_no, level, message = match.groups()
+              annotation = "error" if level == "error" else "warning"
+              print(f"::{annotation} file={file_path},line={line_no},col={col_no}::{escape_workflow_command(message)}")
+          PY
+
+          issue_count="$(grep -c '.' shellcheck-blocking.gcc || true)"
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+          echo "issue_count=${issue_count}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run Informational ShellCheck Pass
+        id: shellcheck_info
+        if: steps.collect_targets.outputs.count != '0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          mapfile -t shell_files < shellcheck-targets.txt
+
+          set +e
+          shellcheck --severity=style --format=gcc -i SC1090,SC1091 "${shell_files[@]}" > shellcheck-info.gcc
+          status=$?
+          set -e
+
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          def escape_workflow_command(value):
+              return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+          pattern = re.compile(r"^(.*?):(\d+):(\d+):\s+([a-z]+):\s+(.*)$")
+          for line in Path("shellcheck-info.gcc").read_text().splitlines():
+              match = pattern.match(line)
+              if not match:
+                  print(line)
+                  continue
+              file_path, line_no, col_no, _, message = match.groups()
+              print(f"::notice file={file_path},line={line_no},col={col_no}::{escape_workflow_command(message)}")
+          PY
+
+          issue_count="$(grep -c '.' shellcheck-info.gcc || true)"
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+          echo "issue_count=${issue_count}" >> "${GITHUB_OUTPUT}"
+
+      - name: Finalize ShellCheck Result
+        if: success() || failure()
+        shell: bash
+        run: |
+          target_count="${{ steps.collect_targets.outputs.count }}"
+          blocking_status="${{ steps.shellcheck_blocking.outputs.status }}"
+          blocking_issues="${{ steps.shellcheck_blocking.outputs.issue_count }}"
+          info_issues="${{ steps.shellcheck_info.outputs.issue_count }}"
+
+          if [[ "${target_count}" == "0" ]]; then
+            {
+              echo "### ShellCheck"
+              echo
+              echo "✅ No tracked sh/bash files matched the scan patterns."
+              echo
+              echo "Coverage: future tracked sh/bash helpers will be scanned automatically when added to the repository."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "### ShellCheck"
+            echo
+            echo "- Files scanned: ${target_count}"
+            echo "- Blocking findings: ${blocking_issues:-0}"
+            echo "- Informational findings (SC1090/SC1091): ${info_issues:-0}"
+            echo "- Coverage: tracked sh/bash-shebang helpers across repository content when present."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${blocking_status}" == "0" ]]; then
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "✅ No blocking ShellCheck issues found" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "❌ Blocking ShellCheck issues found" >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
+  summary:
+    name: Security Scan Summary
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - semgrep
+      - gitleaks
+      - zsh_syntax
+      - shellcheck
+    steps:
+      - name: Security Scan Complete
+        if: success() || failure()
+        shell: bash
+        run: |
+          semgrep_result="${{ needs.semgrep.result }}"
+          gitleaks_result="${{ needs.gitleaks.result }}"
+          zsh_syntax_result="${{ needs.zsh_syntax.result }}"
+          shellcheck_result="${{ needs.shellcheck.result }}"
+
+          badge() {
+            case "$1" in
+              success) printf "✅" ;;
+              skipped) printf "⏭️" ;;
+              cancelled) printf "🚫" ;;
+              *) printf "❌" ;;
+            esac
+          }
+
+          semgrep_badge="$(badge "${semgrep_result}")"
+          gitleaks_badge="$(badge "${gitleaks_result}")"
+          zsh_syntax_badge="$(badge "${zsh_syntax_result}")"
+          shellcheck_badge="$(badge "${shellcheck_result}")"
+
+          {
+            echo "## Security Scan Summary"
+            echo
+            echo "Semgrep ${semgrep_badge} | Gitleaks ${gitleaks_badge} | Zsh Syntax ${zsh_syntax_badge} | ShellCheck ${shellcheck_badge}"
+            echo
+            echo "Coverage: reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, tracked zsh helpers in Resources/, tracked assembled zsh artifacts in Artifacts/, future tracked sh/bash helpers, plus full-repository Semgrep and Gitleaks scans."
+            echo
+            if [[ "${semgrep_result}" == "success" && "${gitleaks_result}" == "success" && "${zsh_syntax_result}" == "success" && "${shellcheck_result}" == "success" ]]; then
+              echo "DDM OS Reminder security scan passed."
+            else
+              echo "DDM OS Reminder security scan requires attention."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "Semgrep ${semgrep_badge} | Gitleaks ${gitleaks_badge} | Zsh Syntax ${zsh_syntax_badge} | ShellCheck ${shellcheck_badge}"
+          echo "Coverage: reminderDialog.zsh, launchDaemonManagement.zsh, assemble.zsh, tracked zsh helpers in Resources/, tracked assembled zsh artifacts in Artifacts/, future tracked sh/bash helpers, plus full-repository Semgrep and Gitleaks scans."
+          if [[ "${semgrep_result}" == "success" && "${gitleaks_result}" == "success" && "${zsh_syntax_result}" == "success" && "${shellcheck_result}" == "success" ]]; then
+            echo "DDM OS Reminder security scan passed."
+            exit 0
+          fi
+
+          echo "DDM OS Reminder security scan requires attention."
+          exit 1

--- a/Resources/README.md
+++ b/Resources/README.md
@@ -3,9 +3,10 @@
 ## Scripts
 
 1. [Assemble](#1-assemble)
-2. [Create Self-extracting Script](#2-create-self-extracting-script)
-3. [Create `.plist`](#3-create-plist)
-4. [Extension Attributes](#4-extension-attributes)
+2. [Preference Preview](#2-preference-preview)
+3. [Create Self-extracting Script](#3-create-self-extracting-script)
+4. [Create `.plist`](#4-create-plist-optional)
+5. [Extension Attributes](#5-extension-attributes)
 
 ---
 
@@ -136,7 +137,7 @@ The `assemble.zsh` script creates **all three files you need for deployment**:
 All artifacts are saved to the `Artifacts/` folder and include the lane suffix:
 `-dev`, `-test`, or `-prod`.
 
-After carefully reviewing and customizing either the `.plist` or `.mobileconfig`, you can deploy the appropriate artifacts directly to your Macs using your MDM, or proceed to [2. Create Self-extracting Script](#2-create-self-extracting-script) below.
+After carefully reviewing and customizing either the `.plist` or `.mobileconfig`, you can deploy the appropriate artifacts directly to your Macs using your MDM, or proceed to [3. Create Self-extracting Script](#3-create-self-extracting-script) below.
 
 When comparing a newly generated `.plist` to an older one, prefer a normalized diff instead of a raw XML comparison:
 
@@ -146,19 +147,48 @@ diff -u <(plutil -p OLD.plist) <(plutil -p NEW.plist)
 
 This filters out comment, key-order, and whitespace churn so you can focus on actual preference-value changes.
 
-> **Note:** The [Create `.plist`](#3-create-plist-optional) step is now **optional** since `assemble.zsh` already generates both `.plist` and `.mobileconfig` files. Use it only if you need to regenerate configuration files from an already-assembled script.
+> **Note:** The [Create `.plist`](#4-create-plist-optional) step is now **optional** since `assemble.zsh` already generates both `.plist` and `.mobileconfig` files. Use it only if you need to regenerate configuration files from an already-assembled script.
 
 > **Localization (optional):** Configure `LanguageOverride` as `auto` or any language code that has a matching `TitleLocalized_<code>` key, and add the corresponding `*_Localized_<code>` families in `Resources/sample.plist` for dialog text, warnings, staging text, support-assistance messaging, infobox labels, deadline messaging, and past-deadline restart copy. `assemble.zsh` and `Resources/createPlist.zsh` both preserve additional language families present in `sample.plist`.
 
 ---
 
-### 2. Create Self-extracting Script
+### 2. Preference Preview
+
+Use [`reminderDialogPreferenceTest.zsh`](reminderDialogPreferenceTest.zsh) to preview how the reminder dialog will render from deployed preferences without running the full DDM deadline-resolution workflow or LaunchDaemon logic.
+
+This helper:
+- Reads the same managed/local preference domain hierarchy as `reminderDialog.zsh`
+- Applies `LanguageOverride` and `*Localized_<code>` keys
+- Uses demo runtime values for deadline/version placeholders so the dialog is fully renderable
+- Wires the dialog buttons for preview use:
+  - Primary button opens Software Update in System Settings
+  - Secondary button dismisses the preview
+  - Info button opens `InfoButtonAction`
+
+**2.1.** Run the preview
+
+```zsh
+zsh Resources/reminderDialogPreferenceTest.zsh
+zsh Resources/reminderDialogPreferenceTest.zsh --rdnn us.snelson
+```
+
+**2.2.** Notes
+
+- The script does not require root, though it can still be run with `sudo` when needed for preference access testing.
+- Use `--rdnn` to target the managed/local preference domain you want to validate.
+- If no deployed preferences exist yet, you can copy `Resources/sample.plist` into `/Library/Preferences/<rdnn>.dorm.plist` for quick local testing.
+- The preview script is intentionally limited to the standard reminder dialog; it does not simulate past-deadline restart modes or LaunchDaemon execution.
+
+---
+
+### 3. Create Self-extracting Script
 
 With some MDMs, it's easier to deploy a **self-extracting script**. After [assembling the script](#1-assemble), run the provided [`createSelfExtracting.zsh`](createSelfExtracting.zsh) script to generate a self-extracting version.
 
 This script automatically finds the **newest assembled script** in the `Artifacts/` folder and creates a base64-encoded, self-extracting version.
 
-**2.1.** Execute the script:
+**3.1.** Execute the script:
 
 ```zsh
 zsh Resources/createSelfExtracting.zsh
@@ -176,19 +206,19 @@ zsh Resources/createSelfExtracting.zsh
 When run, it will extract to /var/tmp/ddm-os-reminder-us.snelson-2026-01-08-054323.zsh and execute automatically.
 ```
 
-**2.2.** The resulting self-extracting script will be created in the `Artifacts/` folder as:
+**3.2.** The resulting self-extracting script will be created in the `Artifacts/` folder as:
 
 ```
 Artifacts/ddm-os-reminder-RDNN-YYYY-MM-DD-HHMMSS_self-extracting-YYYY-MM-DD-HHMMSS.sh
 ```
 
-**2.3.** Deploy the assembled, self-extracting script
+**3.3.** Deploy the assembled, self-extracting script
 
 You can deploy the assembled, self-extracting script to your Macs using your MDM of choice. When executed, it extracts the assembled payload to `/var/tmp` and executes it automatically.
 
 ---
 
-### 3. Create `.plist` (Optional)
+### 4. Create `.plist` (Optional)
 
 > **Note:** This step is now **optional** since `assemble.zsh` already generates both `.plist` and `.mobileconfig` files in the `Artifacts/` folder.
 > 
@@ -218,13 +248,13 @@ SUCCESS! mobileconfig generated:
 
 ---
 
-### 4. Extension Attributes
+### 5. Extension Attributes
 
 While the following Extension Attributes were created for and tested on **Jamf Pro**, they can likely be adapted for other MDMs.
 
 (For adaptation help, visit the [Mac Admins Slack](https://www.macadmins.org/) `#ddm-os-reminders` channel or open an [issue](https://github.com/dan-snelson/DDM-OS-Reminder/issues).)
 
-**4.1.** [`JamfEA-DDM-OS-Reminder-User-Clicks.zsh`](JamfEA-DDM-OS-Reminder-User-Clicks.zsh)  
+**5.1.** [`JamfEA-DDM-OS-Reminder-User-Clicks.zsh`](JamfEA-DDM-OS-Reminder-User-Clicks.zsh)  
 Reports the user’s button clicks from the DDM OS Reminder message.
 
 ```
@@ -235,7 +265,7 @@ Reports the user’s button clicks from the DDM OS Reminder message.
 2026-01-08 03:48:27 dan clicked KB0054571
 ```
 
-**4.2.** [`JamfEA-Pending_OS_Update_Date.zsh`](JamfEA-Pending_OS_Update_Date.zsh)  
+**5.2.** [`JamfEA-Pending_OS_Update_Date.zsh`](JamfEA-Pending_OS_Update_Date.zsh)  
 Reports the date of a pending DDM-enforced macOS update when the recent `install.log` state is trustworthy.
 Because this Extension Attribute is typically configured with a Jamf Pro `Date` data type, non-resolved states return documented sentinel dates instead of text.
 `2000-01-01 00:00:00` = no pending update / already compliant (`None`)
@@ -250,7 +280,7 @@ Uses a safe future padded enforcement date when one is present; otherwise falls 
 2026-01-17 12:00:00
 ```
 
-**4.3.** [`JamfEA-Pending_OS_Update_Version.zsh`](JamfEA-Pending_OS_Update_Version.zsh)  
+**5.3.** [`JamfEA-Pending_OS_Update_Version.zsh`](JamfEA-Pending_OS_Update_Version.zsh)  
 Reports the version of a pending DDM-enforced macOS update when the recent `install.log` state is trustworthy.
 Returns the specific resolver states `conflict`, `noMatch`, `missing`, or `invalidVersion` when the EA cannot safely determine an accurate version.
 Returns `None` only when no pending update should be reported because the resolved declaration already matches or is older than the current OS build/product version.
@@ -259,14 +289,14 @@ Returns `None` only when no pending update should be reported because the resolv
 26.2
 ```
 
-**4.4.** [`JamfEA-DDM_Executed_OS_Update_Date.zsh`](JamfEA-DDM_Executed_OS_Update_Date.zsh)  
+**5.4.** [`JamfEA-DDM_Executed_OS_Update_Date.zsh`](JamfEA-DDM_Executed_OS_Update_Date.zsh)  
 Reports the date when the DDM-enforced macOS update was executed.
 
 ```
 Thu Nov 13 08:59:56 2025
 ```
 
-**4.5.** [`JamfEA-SecureToken_Users.zsh`](JamfEA-SecureToken_Users.zsh)
+**5.5.** [`JamfEA-SecureToken_Users.zsh`](JamfEA-SecureToken_Users.zsh)
 Reports all local users with SecureToken enabled (comma-separated).
 
 ```
@@ -279,7 +309,7 @@ On macOS earlier than 10.13, this EA reports:
 N/A (macOS X.Y.Z)
 ```
 
-**4.6.** [`JamfEA-Volume_Owners.zsh`](JamfEA-Volume_Owners.zsh)
+**5.6.** [`JamfEA-Volume_Owners.zsh`](JamfEA-Volume_Owners.zsh)
 Reports local accounts that are APFS Volume Owners (comma-separated), based on `diskutil apfs listUsers /`.
 
 ```

--- a/Resources/reminderDialogPreferenceTest.zsh
+++ b/Resources/reminderDialogPreferenceTest.zsh
@@ -6,8 +6,9 @@
 # Declarative Device Management macOS Reminder: Preference Preview
 #
 # This standalone preview script reads DDM OS Reminder preferences, resolves
-# localized dialog content, and displays the standard reminder dialog with demo
-# runtime values so Mac Admins can validate Configuration Profile deployment.
+# localized dialog content, and displays the standard reminder dialog using
+# preview runtime values so Mac Admins can validate Configuration Profile
+# deployment.
 #
 # Usage:
 #   zsh Resources/reminderDialogPreferenceTest.zsh

--- a/Resources/reminderDialogPreferenceTest.zsh
+++ b/Resources/reminderDialogPreferenceTest.zsh
@@ -1,0 +1,1310 @@
+#!/bin/zsh --no-rcs
+# shellcheck shell=bash
+
+####################################################################################################
+#
+# Declarative Device Management macOS Reminder: Preference Preview
+#
+# This standalone preview script reads DDM OS Reminder preferences, resolves
+# localized dialog content, and displays the standard reminder dialog with demo
+# runtime values so Mac Admins can validate Configuration Profile deployment.
+#
+# Usage:
+#   zsh Resources/reminderDialogPreferenceTest.zsh
+#   zsh Resources/reminderDialogPreferenceTest.zsh --rdnn org.churchofjesuschrist
+#
+# Notes:
+# - To test another language, set `LanguageOverride` in the target preference
+#   domain (for example: `defaults write /Library/Preferences/org.churchofjesuschrist.dorm
+#   LanguageOverride -string "de"`), then re-run this script.
+# - This script previews dialog appearance only. It intentionally omits DDM log
+#   parsing, LaunchDaemon behavior, meeting-aware delays, and enforcement logic.
+#
+# http://snelson.us/ddm
+#
+####################################################################################################
+
+
+
+####################################################################################################
+#
+# Argument Parsing
+#
+####################################################################################################
+
+cliReverseDomainNameNotation=""
+
+while [[ "$#" -gt 0 ]]; do
+    case "${1}" in
+        --rdnn)
+            if [[ -z "${2:-}" ]]; then
+                echo "Usage: zsh Resources/reminderDialogPreferenceTest.zsh [--rdnn <value>]"
+                exit 64
+            fi
+
+            cliReverseDomainNameNotation="${2}"
+            shift 2
+            ;;
+        *)
+            echo "Usage: zsh Resources/reminderDialogPreferenceTest.zsh [--rdnn <value>]"
+            exit 64
+            ;;
+    esac
+done
+
+
+
+####################################################################################################
+#
+# Global Variables
+#
+####################################################################################################
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local:/usr/local/bin
+
+scriptVersion="3.2.0b1"
+humanReadableScriptName="DDM OS Reminder Preference Preview"
+errorCount=0
+
+autoload -Uz is-at-least
+
+typeset -ga temporaryFiles=()
+declare -A preferenceExplicitlySet=()
+
+foundManagedPreferences="false"
+foundLocalPreferences="false"
+dialogLanguage="en"
+dialogSupportsMarkdownColor="NO"
+hideSecondaryButton="NO"
+blurscreen="--noblurscreen"
+updateOrUpgradeMode="update"
+updateStagingStatus="Fully staged"
+requestedAppearanceMode=""
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Organization Variables
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+reverseDomainNameNotation="${cliReverseDomainNameNotation:-org.churchofjesuschrist}"
+organizationScriptName="dorm"
+
+# Preference plist domains
+preferenceDomain="${reverseDomainNameNotation}.${organizationScriptName}"
+managedPreferencesPlist="/Library/Managed Preferences/${preferenceDomain}"
+localPreferencesPlist="/Library/Preferences/${preferenceDomain}"
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Preference Configuration Map
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+declare -A preferenceConfiguration=(
+    ["daysOfExcessiveUptimeWarning"]="numeric|0"
+    ["minimumDiskFreePercentage"]="numeric|99"
+    ["organizationOverlayiconURL"]="string|https://use2.ics.services.jamfcloud.com/icon/hash_2d64ce7f0042ad68234a2515211adb067ad6714703dd8ebd6f33c1ab30354b1d"
+    ["organizationOverlayiconURLdark"]="string|https://use2.ics.services.jamfcloud.com/icon/hash_d3a3bc5e06d2db5f9697f9b4fa095bfecb2dc0d22c71aadea525eb38ff981d39"
+    ["swapOverlayAndLogo"]="boolean|NO"
+    ["dateFormatDeadlineHumanReadable"]="string|+%a, %d-%b-%Y, %-l:%M %p"
+    ["supportTeamName"]="string|IT Support"
+    ["supportTeamPhone"]="string|+1 (801) 555-1212"
+    ["supportTeamEmail"]="string|rescue@domain.org"
+    ["supportTeamWebsite"]="string|https://support.domain.org"
+    ["supportKB"]="string|Update macOS on Mac"
+    ["infobuttonaction"]="string|https://support.apple.com/108382"
+    ["supportKBURL"]="string|[Update macOS on Mac](https://support.apple.com/108382)"
+    ["supportAssistanceMessage"]="string|<br><br>For assistance, please contact **{supportTeamName}** by clicking the (?) button in the bottom, right-hand corner."
+    ["languageOverride"]="string|auto"
+    ["title"]="string|macOS {titleMessageUpdateOrUpgrade} Required"
+    ["button1text"]="string|Open Software Update"
+    ["button2text"]="string|Remind Me Later"
+    ["infobuttontext"]="string|Update macOS on Mac"
+    ["excessiveUptimeWarningMessage"]="string|<br><br>**Note:** Your Mac has been powered-on for **{uptimeHumanReadable}**. For more reliable results, please manually restart your Mac before proceeding."
+    ["diskSpaceWarningMessage"]="string|<br><br>**Note:** Your Mac has only **{diskSpaceHumanReadable}**, which may prevent this macOS {titleMessageUpdateOrUpgrade:l}."
+    ["stagedUpdateMessage"]="string|<br><br>**Good news!** The macOS {ddmVersionString} update has already been downloaded to your Mac and is ready to install. Installation will proceed quickly when you click **{button1text}**."
+    ["partiallyStagedUpdateMessage"]="string|<br><br>Your Mac has begun downloading and preparing required macOS update components. Installation will be quicker once all assets have finished staging."
+    ["pendingDownloadMessage"]="string|<br><br>Your Mac will begin downloading the update shortly."
+    ["hideStagedInfo"]="boolean|NO"
+    ["relativeDeadlineToday"]="string|Today"
+    ["relativeDeadlineTomorrow"]="string|Tomorrow"
+    ["updateWord"]="string|Update"
+    ["upgradeWord"]="string|Upgrade"
+    ["softwareUpdateButtonTextUpdate"]="string|Restart Now"
+    ["softwareUpdateButtonTextUpgrade"]="string|Upgrade Now"
+    ["restartNowButtonText"]="string|Restart Now"
+    ["infoboxLabelCurrent"]="string|Current"
+    ["infoboxLabelRequired"]="string|Required"
+    ["infoboxLabelDeadline"]="string|Deadline"
+    ["infoboxLabelDaysRemaining"]="string|Day(s) Remaining"
+    ["infoboxLabelLastRestart"]="string|Last Restart"
+    ["infoboxLabelFreeDiskSpace"]="string|Free Disk Space"
+    ["deadlineEnforcementMessageAbsolute"]="string|However, your Mac **will automatically restart and {titleMessageUpdateOrUpgrade:l}** on **{deadlineDisplay}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline."
+    ["deadlineEnforcementMessageRelative"]="string|However, your Mac **will automatically restart and {titleMessageUpdateOrUpgrade:l}** **{deadlineDisplay}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline."
+    ["message"]="string|**A required macOS {titleMessageUpdateOrUpgrade:l} is now available**<br><br>Happy {weekday}, {loggedInUserFirstname}!<br><br>Please {titleMessageUpdateOrUpgrade:l} to macOS **{ddmVersionString}** to ensure your Mac remains secure and compliant with organizational policies.{updateReadyMessage}<br><br>To perform the {titleMessageUpdateOrUpgrade:l} now, click **{button1text}**, review the on-screen instructions, then click **{softwareUpdateButtonText}**.<br><br>If you are unable to perform this {titleMessageUpdateOrUpgrade:l} now, click **{button2text}** to be reminded again later (which is disabled when the deadline is imminent).<br><br>{deadlineEnforcementMessage}{excessiveUptimeWarningMessage}{diskSpaceWarningMessage}{supportAssistanceMessage}"
+    ["infobox"]="string|**{infoboxLabelCurrent}:** macOS {installedmacOSVersion}<br><br>**{infoboxLabelRequired}:** macOS {ddmVersionString}<br><br>**{infoboxLabelDeadline}:** {infoboxDeadlineDisplay}<br><br>**{infoboxLabelDaysRemaining}:** {infoboxDaysRemainingDisplay}<br><br>**{infoboxLabelLastRestart}:** {infoboxLastRestartDisplay}<br><br>**{infoboxLabelFreeDiskSpace}:** {diskSpaceHumanReadable}"
+    ["helpmessage"]="string|For assistance, please contact: **{supportTeamName}**<br>- **Telephone:** {supportTeamPhone}<br>- **Email:** {supportTeamEmail}<br>- **Website:** {supportTeamWebsite}<br>- **Knowledge Base Article:** {supportKBURL}<br><br>**User Information:**<br>- **Full Name:** {userfullname}<br>- **User Name:** {username}<br><br>**Computer Information:**<br>- **Computer Name:** {computername}<br>- **Serial Number:** {serialnumber}<br>- **macOS:** {osversion}<br><br>**Script Information:**<br>- **Dialog:** {dialogVersion}<br>- **Script:** {scriptVersion}<br>"
+    ["helpimage"]="string|qr={infobuttonaction}"
+)
+
+declare -A plistKeyMap=(
+    ["daysOfExcessiveUptimeWarning"]="DaysOfExcessiveUptimeWarning"
+    ["minimumDiskFreePercentage"]="MinimumDiskFreePercentage"
+    ["organizationOverlayiconURL"]="OrganizationOverlayIconURL"
+    ["organizationOverlayiconURLdark"]="OrganizationOverlayIconURLdark"
+    ["swapOverlayAndLogo"]="SwapOverlayAndLogo"
+    ["dateFormatDeadlineHumanReadable"]="DateFormatDeadlineHumanReadable"
+    ["supportTeamName"]="SupportTeamName"
+    ["supportTeamPhone"]="SupportTeamPhone"
+    ["supportTeamEmail"]="SupportTeamEmail"
+    ["supportTeamWebsite"]="SupportTeamWebsite"
+    ["supportKB"]="SupportKB"
+    ["infobuttonaction"]="InfoButtonAction"
+    ["supportKBURL"]="SupportKBURL"
+    ["supportAssistanceMessage"]="SupportAssistanceMessage"
+    ["languageOverride"]="LanguageOverride"
+    ["title"]="Title"
+    ["button1text"]="Button1Text"
+    ["button2text"]="Button2Text"
+    ["infobuttontext"]="InfoButtonText"
+    ["excessiveUptimeWarningMessage"]="ExcessiveUptimeWarningMessage"
+    ["diskSpaceWarningMessage"]="DiskSpaceWarningMessage"
+    ["stagedUpdateMessage"]="StagedUpdateMessage"
+    ["partiallyStagedUpdateMessage"]="PartiallyStagedUpdateMessage"
+    ["pendingDownloadMessage"]="PendingDownloadMessage"
+    ["hideStagedInfo"]="HideStagedUpdateInfo"
+    ["relativeDeadlineToday"]="RelativeDeadlineToday"
+    ["relativeDeadlineTomorrow"]="RelativeDeadlineTomorrow"
+    ["updateWord"]="UpdateWord"
+    ["upgradeWord"]="UpgradeWord"
+    ["softwareUpdateButtonTextUpdate"]="SoftwareUpdateButtonTextUpdate"
+    ["softwareUpdateButtonTextUpgrade"]="SoftwareUpdateButtonTextUpgrade"
+    ["restartNowButtonText"]="RestartNowButtonText"
+    ["infoboxLabelCurrent"]="InfoboxLabelCurrent"
+    ["infoboxLabelRequired"]="InfoboxLabelRequired"
+    ["infoboxLabelDeadline"]="InfoboxLabelDeadline"
+    ["infoboxLabelDaysRemaining"]="InfoboxLabelDaysRemaining"
+    ["infoboxLabelLastRestart"]="InfoboxLabelLastRestart"
+    ["infoboxLabelFreeDiskSpace"]="InfoboxLabelFreeDiskSpace"
+    ["deadlineEnforcementMessageAbsolute"]="DeadlineEnforcementMessageAbsolute"
+    ["deadlineEnforcementMessageRelative"]="DeadlineEnforcementMessageRelative"
+    ["message"]="Message"
+    ["infobox"]="InfoBox"
+    ["helpmessage"]="HelpMessage"
+    ["helpimage"]="HelpImage"
+)
+
+
+
+####################################################################################################
+#
+# Functions
+#
+####################################################################################################
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Console Logging
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function updateConsoleLog() {
+    echo "${organizationScriptName} (${scriptVersion}): $( date +%Y-%m-%d\ %H:%M:%S ) - ${1}"
+}
+
+function preFlight()    { updateConsoleLog "[PRE-FLIGHT]      ${1}"; }
+function notice()       { updateConsoleLog "[NOTICE]          ${1}"; }
+function info()         { updateConsoleLog "[INFO]            ${1}"; }
+function warning()      { updateConsoleLog "[WARNING]         ${1}"; let errorCount++; }
+function error()        { updateConsoleLog "[ERROR]           ${1}"; let errorCount++; }
+function fatal()        { updateConsoleLog "[FATAL ERROR]     ${1}"; exit 1; }
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Cleanup
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function cleanupTemporaryFiles() {
+    local filePath=""
+
+    for filePath in "${temporaryFiles[@]}"; do
+        [[ -n "${filePath}" && -e "${filePath}" ]] && rm -f "${filePath}"
+    done
+}
+
+trap cleanupTemporaryFiles EXIT
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Preference Utilities
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function plistFileIsReadable() {
+    local plistPath="${1}"
+
+    [[ -f "${plistPath}" ]] || return 1
+
+    /usr/bin/plutil -lint "${plistPath}" >/dev/null 2>&1
+}
+
+function readPlistValue() {
+    local plistPath="${1}"
+    local plistKey="${2}"
+    local plistValue=""
+
+    plistValue=$(/usr/libexec/PlistBuddy -c "Print :${plistKey}" "${plistPath}" 2>/dev/null)
+    echo "${plistValue}"
+}
+
+function currentConsoleUser() {
+    echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }'
+}
+
+function resolveEffectiveUserContext() {
+    local currentUser="$(id -un 2>/dev/null)"
+    local consoleUser="$(currentConsoleUser)"
+
+    if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+        loggedInUser="${SUDO_USER}"
+        notice "Running with sudo; resolving language and appearance for '${loggedInUser}'."
+    elif [[ -n "${currentUser}" && "${currentUser}" != "root" ]]; then
+        loggedInUser="${currentUser}"
+    elif [[ -n "${consoleUser}" && "${consoleUser}" != "loginwindow" && "${consoleUser}" != "root" ]]; then
+        loggedInUser="${consoleUser}"
+    else
+        fatal "Unable to determine a non-root user context for preview."
+    fi
+
+    if ! id "${loggedInUser}" >/dev/null 2>&1; then
+        fatal "Resolved user '${loggedInUser}' does not exist on this Mac."
+    fi
+
+    loggedInUserID=$(id -u "${loggedInUser}" 2>/dev/null)
+    loggedInUserFullname=$(id -F "${loggedInUser}" 2>/dev/null)
+    [[ -z "${loggedInUserFullname}" ]] && loggedInUserFullname="${loggedInUser}"
+
+    loggedInUserFirstname=$(echo "${loggedInUserFullname}" | sed -E 's/^.*, // ; s/([^ ]*).*/\1/' | sed 's/\(.\{25\}\).*/\1…/' | awk '{print ( $0 == toupper($0) ? toupper(substr($0,1,1))substr(tolower($0),2) : toupper(substr($0,1,1))substr($0,2) )}')
+    [[ -z "${loggedInUserFirstname}" ]] && loggedInUserFirstname="${loggedInUser}"
+
+    loggedInUserHomeDirectory=$(dscl . read "/Users/${loggedInUser}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+    [[ -z "${loggedInUserHomeDirectory}" && "${USER:-}" == "${loggedInUser}" ]] && loggedInUserHomeDirectory="${HOME}"
+
+    preFlight "Effective user: ${loggedInUser} (${loggedInUserID})"
+    preFlight "Effective user home: ${loggedInUserHomeDirectory}"
+}
+
+function normalizeBooleanValue() {
+    local value="${1}"
+
+    case "${value:l}" in
+        1|true|yes) echo "YES" ;;
+        0|false|no) echo "NO" ;;
+        *)          echo "" ;;
+    esac
+}
+
+function loadDefaultPreferences() {
+    local prefKey=""
+
+    preferenceExplicitlySet=()
+
+    for prefKey in "${(@k)preferenceConfiguration}"; do
+        local prefConfig="${preferenceConfiguration[$prefKey]}"
+        local defaultValue="${prefConfig#*|}"
+        printf -v "${prefKey}" '%s' "${defaultValue}"
+    done
+}
+
+function internalPreferenceKeyForPlistKey() {
+    local plistKey="${1}"
+    local prefKey=""
+
+    for prefKey in "${(@k)preferenceConfiguration}"; do
+        if [[ "${plistKeyMap[$prefKey]:-$prefKey}" == "${plistKey}" ]]; then
+            echo "${prefKey}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+function isKnownPreferencePlistKey() {
+    internalPreferenceKeyForPlistKey "${1}" >/dev/null 2>&1
+}
+
+function setNumericPreferenceValue() {
+    local targetVariable="${1}"
+    local rawValue="${2}"
+
+    if [[ "${rawValue}" =~ ^[0-9]+$ ]] && (( rawValue >= 0 && rawValue <= 999 )); then
+        printf -v "${targetVariable}" '%s' "${rawValue}"
+        preferenceExplicitlySet["${targetVariable}"]="true"
+    else
+        warning "Ignoring invalid numeric value '${rawValue}' for '${targetVariable}'; keeping default '${(P)targetVariable}'."
+    fi
+}
+
+function setBooleanPreferenceValue() {
+    local targetVariable="${1}"
+    local rawValue="${2}"
+    local normalizedValue=""
+
+    normalizedValue="$(normalizeBooleanValue "${rawValue}")"
+    if [[ -n "${normalizedValue}" ]]; then
+        printf -v "${targetVariable}" '%s' "${normalizedValue}"
+        preferenceExplicitlySet["${targetVariable}"]="true"
+    else
+        warning "Ignoring invalid boolean value '${rawValue}' for '${targetVariable}'; keeping default '${(P)targetVariable}'."
+    fi
+}
+
+function setStringPreferenceValue() {
+    local targetVariable="${1}"
+    local rawValue="${2}"
+
+    printf -v "${targetVariable}" '%s' "${rawValue}"
+    preferenceExplicitlySet["${targetVariable}"]="true"
+}
+
+function languageSuffixForCode() {
+    local code="${1:l}"
+
+    [[ -z "${code}" || "${code}" == "en" ]] && echo "En" && return
+
+    echo "${(C)code}"
+}
+
+function loadDynamicLocalizedPreferenceOverridesFromPlist() {
+    local plistPath="${1}"
+    local rawKey=""
+    local -a plistKeys=()
+
+    while IFS= read -r rawKey; do
+        [[ -n "${rawKey}" ]] && plistKeys+=("${rawKey}")
+    done < <(/usr/libexec/PlistBuddy -c "Print" "${plistPath}" 2>/dev/null | awk '
+        /^    / && /Localized_/ {
+            key=$0
+            sub(/^    /, "", key)
+            sub(/ =.*/, "", key)
+            print key
+        }
+    ')
+
+    for rawKey in "${plistKeys[@]}"; do
+        local baseRaw="${rawKey%%Localized_*}"
+        local codePart="${rawKey##*Localized_}"
+        local internalBase=""
+        local internalSuffix=""
+        local internalKey=""
+        local dynamicValue=""
+
+        [[ -z "${baseRaw}" || -z "${codePart}" ]] && continue
+
+        if internalBase="$(internalPreferenceKeyForPlistKey "${baseRaw}")"; then
+            :
+        else
+            internalBase="${baseRaw:0:1:l}${baseRaw:1}"
+        fi
+
+        internalSuffix="$(languageSuffixForCode "${codePart}")"
+        internalKey="${internalBase}Localized${internalSuffix}"
+        dynamicValue="$(readPlistValue "${plistPath}" "${rawKey}")"
+
+        printf -v "${internalKey}" '%s' "${dynamicValue}"
+        preferenceExplicitlySet["${internalKey}"]="true"
+    done
+}
+
+function loadPreferenceOverrides() {
+    local prefKey=""
+
+    loadDefaultPreferences
+
+    if plistFileIsReadable "${managedPreferencesPlist}.plist"; then
+        foundManagedPreferences="true"
+        preFlight "Reading managed preferences from '${managedPreferencesPlist}.plist'"
+    elif [[ -f "${managedPreferencesPlist}.plist" ]]; then
+        warning "Managed preferences plist exists but failed validation: ${managedPreferencesPlist}.plist"
+    fi
+
+    if plistFileIsReadable "${localPreferencesPlist}.plist"; then
+        foundLocalPreferences="true"
+        preFlight "Reading local preferences from '${localPreferencesPlist}.plist'"
+    elif [[ -f "${localPreferencesPlist}.plist" ]]; then
+        warning "Local preferences plist exists but failed validation: ${localPreferencesPlist}.plist"
+    fi
+
+    if [[ "${foundManagedPreferences}" == "false" && "${foundLocalPreferences}" == "false" ]]; then
+        warning "No valid preference plist found for domain '${preferenceDomain}'."
+        return 1
+    fi
+
+    for prefKey in "${(@k)preferenceConfiguration}"; do
+        local prefConfig="${preferenceConfiguration[$prefKey]}"
+        local prefType="${prefConfig%%|*}"
+        local plistKey="${plistKeyMap[$prefKey]:-$prefKey}"
+        local sourcePlist=""
+        local rawValue=""
+
+        if [[ "${foundManagedPreferences}" == "true" ]] && /usr/libexec/PlistBuddy -c "Print :${plistKey}" "${managedPreferencesPlist}.plist" >/dev/null 2>&1; then
+            sourcePlist="${managedPreferencesPlist}.plist"
+        elif [[ "${foundLocalPreferences}" == "true" ]] && /usr/libexec/PlistBuddy -c "Print :${plistKey}" "${localPreferencesPlist}.plist" >/dev/null 2>&1; then
+            sourcePlist="${localPreferencesPlist}.plist"
+        else
+            continue
+        fi
+
+        rawValue="$(readPlistValue "${sourcePlist}" "${plistKey}")"
+
+        case "${prefType}" in
+            numeric)
+                setNumericPreferenceValue "${prefKey}" "${rawValue}"
+                ;;
+            boolean)
+                setBooleanPreferenceValue "${prefKey}" "${rawValue}"
+                ;;
+            string|*)
+                setStringPreferenceValue "${prefKey}" "${rawValue}"
+                ;;
+        esac
+    done
+
+    if [[ "${foundLocalPreferences}" == "true" ]]; then
+        loadDynamicLocalizedPreferenceOverridesFromPlist "${localPreferencesPlist}.plist"
+    fi
+
+    if [[ "${foundManagedPreferences}" == "true" ]]; then
+        loadDynamicLocalizedPreferenceOverridesFromPlist "${managedPreferencesPlist}.plist"
+    fi
+
+    [[ -n "${dateFormatDeadlineHumanReadable}" && "${dateFormatDeadlineHumanReadable}" != +* ]] && dateFormatDeadlineHumanReadable="+${dateFormatDeadlineHumanReadable}"
+
+    preFlight "Preferences loaded"
+    return 0
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Localization and Date Formatting
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function localeForDialogLanguageCode() {
+    local languageCode="${1:l}"
+    local discoveredLocale=""
+
+    discoveredLocale=$(locale -a 2>/dev/null | awk -v code="${languageCode}" '
+        BEGIN { IGNORECASE = 1 }
+        {
+            localeLower = tolower($0)
+            if (localeLower ~ ("^" code "(_[^[:space:]]+)?(\\.utf-?8)?$")) {
+                print $0
+                exit
+            }
+        }
+    ')
+
+    if [[ -n "${discoveredLocale}" ]]; then
+        echo "${discoveredLocale}"
+        return
+    fi
+
+    case "${languageCode}" in
+        de) echo "de_DE.UTF-8" ;;
+        en) echo "en_US.UTF-8" ;;
+        es) echo "es_ES.UTF-8" ;;
+        fr) echo "fr_FR.UTF-8" ;;
+        it) echo "it_IT.UTF-8" ;;
+        ja) echo "ja_JP.UTF-8" ;;
+        nl) echo "nl_NL.UTF-8" ;;
+        pt) echo "pt_PT.UTF-8" ;;
+        *)  echo "" ;;
+    esac
+}
+
+function formatDateWithDialogLocale() {
+    local inputFormat="${1}"
+    local inputValue="${2}"
+    local outputFormat="${3}"
+    local localeForDate=""
+    local formattedDate=""
+
+    localeForDate="$(localeForDialogLanguageCode "${dialogLanguage}")"
+
+    if [[ -n "${localeForDate}" ]]; then
+        formattedDate=$(LC_TIME="${localeForDate}" date -jf "${inputFormat}" "${inputValue}" "${outputFormat}" 2>/dev/null)
+    fi
+
+    if [[ -z "${formattedDate}" ]]; then
+        formattedDate=$(date -jf "${inputFormat}" "${inputValue}" "${outputFormat}" 2>/dev/null)
+    fi
+
+    echo "${formattedDate}"
+}
+
+function formatDeadlineFromEpoch() {
+    local sourceEpoch="${1}"
+    local requestedFormat="${2}"
+    local formattedDeadline=""
+
+    formattedDeadline=$(formatDateWithDialogLocale "%s" "${sourceEpoch}" "${requestedFormat}")
+    if [[ -z "${formattedDeadline}" ]]; then
+        formattedDeadline=$(formatDateWithDialogLocale "%s" "${sourceEpoch}" "+%a, %d-%b-%Y, %-l:%M %p")
+    fi
+
+    echo "${formattedDeadline}"
+}
+
+function formatTimeHumanReadableFromEpoch() {
+    local targetEpoch="${1}"
+    local timeHumanReadable=""
+
+    if [[ -z "${targetEpoch}" ]] || ! [[ "${targetEpoch}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    timeHumanReadable=$(formatDateWithDialogLocale "%s" "${targetEpoch}" "+%-l:%M %p")
+    [[ -z "${timeHumanReadable}" ]] && return 1
+
+    timeHumanReadable=${timeHumanReadable// AM/ a.m.}
+    timeHumanReadable=${timeHumanReadable// PM/ p.m.}
+    echo "${timeHumanReadable}"
+}
+
+function formatRelativeDeadlineHumanReadable() {
+    local targetEpoch="${1}"
+    local absoluteFallback="${2}"
+    local targetDate=""
+    local todayDate=""
+    local tomorrowDate=""
+    local targetTime=""
+    local relativeDeadlineHumanReadable=""
+
+    if [[ -n "${targetEpoch}" && "${targetEpoch}" =~ ^[0-9]+$ ]]; then
+        targetDate=$(date -jf "%s" "${targetEpoch}" "+%Y-%m-%d" 2>/dev/null)
+        todayDate=$(date "+%Y-%m-%d")
+        tomorrowDate=$(date -v+1d "+%Y-%m-%d")
+        targetTime=$(formatTimeHumanReadableFromEpoch "${targetEpoch}" 2>/dev/null)
+
+        if [[ -n "${targetDate}" && -n "${targetTime}" ]]; then
+            if [[ "${targetDate}" == "${todayDate}" ]]; then
+                relativeDeadlineHumanReadable="${relativeDeadlineToday}, ${targetTime}"
+            elif [[ "${targetDate}" == "${tomorrowDate}" ]]; then
+                relativeDeadlineHumanReadable="${relativeDeadlineTomorrow}, ${targetTime}"
+            fi
+        fi
+    fi
+
+    [[ -z "${relativeDeadlineHumanReadable}" ]] && relativeDeadlineHumanReadable="${absoluteFallback}"
+    echo "${relativeDeadlineHumanReadable}"
+}
+
+function detectLoggedInUserLanguageCode() {
+    local globalPreferencesPath="${loggedInUserHomeDirectory}/Library/Preferences/.GlobalPreferences.plist"
+    local detectedLanguage=""
+
+    if [[ -r "${globalPreferencesPath}" ]]; then
+        detectedLanguage=$(/usr/libexec/PlistBuddy -c "Print :AppleLanguages:0" "${globalPreferencesPath}" 2>/dev/null)
+    fi
+
+    echo "${detectedLanguage}"
+}
+
+function normalizeDialogLanguageCode() {
+    local languageCode="${1:l}"
+    local sentinelKey=""
+
+    languageCode="${languageCode#\"}"
+    languageCode="${languageCode%\"}"
+    languageCode="${languageCode#\'}"
+    languageCode="${languageCode%\'}"
+    languageCode="${languageCode%%-*}"
+    languageCode="${languageCode%%_*}"
+
+    [[ "${languageCode}" == "en" ]] && echo "en" && return
+
+    sentinelKey="TitleLocalized_${languageCode}"
+    if [[ "${foundManagedPreferences}" == "true" ]] && /usr/libexec/PlistBuddy -c "Print :${sentinelKey}" "${managedPreferencesPlist}.plist" >/dev/null 2>&1; then
+        echo "${languageCode}"
+        return
+    fi
+
+    if [[ "${foundLocalPreferences}" == "true" ]] && /usr/libexec/PlistBuddy -c "Print :${sentinelKey}" "${localPreferencesPlist}.plist" >/dev/null 2>&1; then
+        echo "${languageCode}"
+        return
+    fi
+
+    echo "en"
+}
+
+function localizedWeekdayName() {
+    local languageCode="${1}"
+    local localeForWeekday=""
+    local localizedWeekday=""
+
+    localeForWeekday="$(localeForDialogLanguageCode "${languageCode}")"
+    if [[ -n "${localeForWeekday}" ]]; then
+        localizedWeekday=$(LC_TIME="${localeForWeekday}" date "+%A" 2>/dev/null)
+    fi
+
+    [[ -z "${localizedWeekday}" ]] && localizedWeekday=$(date "+%A")
+    echo "${localizedWeekday}"
+}
+
+function resolveDialogLanguage() {
+    local normalizedOverride=""
+    local detectedLanguage=""
+
+    if [[ -n "${languageOverride}" && "${languageOverride:l}" != "auto" ]]; then
+        normalizedOverride="$(normalizeDialogLanguageCode "${languageOverride}")"
+        dialogLanguage="${normalizedOverride}"
+        notice "LanguageOverride is '${languageOverride}'; using '${dialogLanguage}'"
+        return
+    fi
+
+    detectedLanguage="$(detectLoggedInUserLanguageCode)"
+    if [[ -z "${detectedLanguage}" ]]; then
+        dialogLanguage="en"
+        notice "Could not detect logged-in user language; defaulting to '${dialogLanguage}'"
+        return
+    fi
+
+    dialogLanguage="$(normalizeDialogLanguageCode "${detectedLanguage}")"
+    notice "Detected logged-in user language '${detectedLanguage}'; using '${dialogLanguage}'"
+}
+
+function applyLocalizedFieldValue() {
+    local baseVariable="${1}"
+    local languageCode="${2}"
+    local localizedSuffix=""
+    local localizedVariable=""
+    local localizedValue=""
+
+    localizedSuffix="$(languageSuffixForCode "${languageCode}")"
+    localizedVariable="${baseVariable}Localized${localizedSuffix}"
+    localizedValue="${(P)localizedVariable}"
+
+    if [[ "${preferenceExplicitlySet[${localizedVariable}]}" == "true" ]]; then
+        printf -v "${baseVariable}" '%s' "${localizedValue}"
+        return
+    fi
+
+    if [[ "${preferenceExplicitlySet[${baseVariable}]}" == "true" ]]; then
+        return
+    fi
+
+    [[ -n "${localizedValue}" ]] && printf -v "${baseVariable}" '%s' "${localizedValue}"
+}
+
+function initializeLocalizedRuntimeFields() {
+    local runtimeField=""
+    local runtimeFields=("relativeDeadlineToday" "relativeDeadlineTomorrow")
+
+    for runtimeField in "${runtimeFields[@]}"; do
+        applyLocalizedFieldValue "${runtimeField}" "${dialogLanguage}"
+    done
+}
+
+function applyLocalizedDialogText() {
+    local localizedField=""
+    local localizedFields=(
+        "title" "button1text" "button2text" "infobuttontext"
+        "message" "helpmessage"
+        "excessiveUptimeWarningMessage" "diskSpaceWarningMessage"
+        "stagedUpdateMessage" "partiallyStagedUpdateMessage" "pendingDownloadMessage"
+        "supportAssistanceMessage"
+        "updateWord" "upgradeWord"
+        "softwareUpdateButtonTextUpdate" "softwareUpdateButtonTextUpgrade" "restartNowButtonText"
+        "infoboxLabelCurrent" "infoboxLabelRequired" "infoboxLabelDeadline"
+        "infoboxLabelDaysRemaining" "infoboxLabelLastRestart" "infoboxLabelFreeDiskSpace"
+        "deadlineEnforcementMessageAbsolute" "deadlineEnforcementMessageRelative"
+    )
+
+    for localizedField in "${localizedFields[@]}"; do
+        applyLocalizedFieldValue "${localizedField}" "${dialogLanguage}"
+    done
+}
+
+function applyLocalizedUpdateVocabulary() {
+    if [[ "${updateOrUpgradeMode:l}" == "upgrade" ]]; then
+        titleMessageUpdateOrUpgrade="${upgradeWord}"
+        softwareUpdateButtonText="${softwareUpdateButtonTextUpgrade}"
+    else
+        titleMessageUpdateOrUpgrade="${updateWord}"
+        softwareUpdateButtonText="${softwareUpdateButtonTextUpdate}"
+    fi
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Local Runtime Facts
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function collectUptimeFacts() {
+    local lastBootTime=""
+    local currentTime=""
+
+    lastBootTime=$(sysctl kern.boottime | awk -F'[ |,]' '{print $5}')
+    currentTime=$(date +"%s")
+    upTimeRaw=$(( currentTime - lastBootTime ))
+    upTimeMin=$(( upTimeRaw / 60 ))
+    upTimeDays=$(( upTimeMin / 1440 ))
+    upTimeHoursRemainder=$(( (upTimeMin % 1440) / 60 ))
+    upTimeMinutesRemainder=$(( upTimeMin % 60 ))
+    uptimeHumanReadable=""
+
+    if [[ "${upTimeDays}" -gt 0 ]]; then
+        if [[ "${upTimeDays}" -eq 1 ]]; then
+            uptimeHumanReadable="1 day"
+        else
+            uptimeHumanReadable="${upTimeDays} days"
+        fi
+    fi
+
+    if [[ "${upTimeHoursRemainder}" -gt 0 ]]; then
+        [[ -n "${uptimeHumanReadable}" ]] && uptimeHumanReadable="${uptimeHumanReadable}, "
+
+        if [[ "${upTimeHoursRemainder}" -eq 1 ]]; then
+            uptimeHumanReadable="${uptimeHumanReadable}1 hour"
+        else
+            uptimeHumanReadable="${uptimeHumanReadable}${upTimeHoursRemainder} hours"
+        fi
+    fi
+
+    if [[ "${upTimeMinutesRemainder}" -gt 0 ]]; then
+        [[ -n "${uptimeHumanReadable}" ]] && uptimeHumanReadable="${uptimeHumanReadable}, "
+
+        if [[ "${upTimeMinutesRemainder}" -eq 1 ]]; then
+            uptimeHumanReadable="${uptimeHumanReadable}1 minute"
+        else
+            uptimeHumanReadable="${uptimeHumanReadable}${upTimeMinutesRemainder} minutes"
+        fi
+    fi
+
+    [[ -z "${uptimeHumanReadable}" ]] && uptimeHumanReadable="less than 1 minute"
+}
+
+function collectDiskFacts() {
+    local diskRawValues=""
+    local freeBytes=""
+    local diskBytes=""
+
+    diskRawValues=$(osascript -l JavaScript -e "ObjC.import('Foundation'); var url = \$.NSURL.fileURLWithPath('/'); var result = url.resourceValuesForKeysError(['NSURLVolumeAvailableCapacityForImportantUsageKey','NSURLVolumeTotalCapacityKey'], null); [result.valueForKey('NSURLVolumeAvailableCapacityForImportantUsageKey').js, result.valueForKey('NSURLVolumeTotalCapacityKey').js].join(' ');" 2>/dev/null)
+    read freeBytes diskBytes <<< "${diskRawValues}"
+
+    if [[ "${freeBytes}" == <-> && "${diskBytes}" == <-> ]] && (( freeBytes > 0 && diskBytes >= freeBytes )); then
+        freeSpace=$(echo "scale=1; ${freeBytes} / 1000000000" | bc)
+        freeSpace="${freeSpace} GB"
+        freePercentage=$(echo "scale=2; (${freeBytes} * 100) / ${diskBytes}" | bc)
+    else
+        warning "JXA disk space query returned invalid data; falling back to diskutil. diskBytes=${diskBytes}, freeBytes=${freeBytes}"
+        freeSpace=$(diskutil info / | awk -F ': ' '/Free Space|Available Space|Container Free Space/ {print $2}' | awk -F '(' '{print $1}' | xargs)
+        diskBytes=$(diskutil info / | awk -F '[()]' '/Total Space/ {print $2}' | awk '{print $1}')
+        freeBytes=$(diskutil info / | awk -F '[()]' '/Free Space|Available Space|Container Free Space/ {print $2}' | awk '{print $1}')
+
+        if [[ "${freeBytes}" == <-> && "${diskBytes}" == <-> ]] && (( diskBytes > 0 && diskBytes >= freeBytes )); then
+            freePercentage=$(echo "scale=2; (${freeBytes} * 100) / ${diskBytes}" | bc)
+        else
+            error "Invalid disk space data: diskBytes=${diskBytes}, freeBytes=${freeBytes}"
+            freeSpace="Unknown"
+            freePercentage="Unknown"
+        fi
+    fi
+
+    diskSpaceHumanReadable="${freeSpace} (${freePercentage}% available)"
+}
+
+function collectMachineFacts() {
+    installedmacOSVersion=$(sw_vers -productVersion 2>/dev/null)
+    [[ -z "${installedmacOSVersion}" ]] && installedmacOSVersion="Unknown"
+
+    username="${loggedInUser}"
+    userfullname="${loggedInUserFullname}"
+    osversion="${installedmacOSVersion}"
+
+    computername=$(scutil --get ComputerName 2>/dev/null)
+    [[ -z "${computername}" ]] && computername="$(hostname -s 2>/dev/null)"
+    [[ -z "${computername}" ]] && computername="Unknown"
+
+    serialnumber=$(ioreg -rd1 -c IOPlatformExpertDevice 2>/dev/null | awk -F'"' '/IOPlatformSerialNumber/ {print $4; exit}')
+    [[ -z "${serialnumber}" ]] && serialnumber="Unknown"
+}
+
+function prepareDemoRuntimeState() {
+    local installedMajorVersion=""
+    local installedMinorVersion="0"
+    local installedPatchVersion="0"
+
+    collectUptimeFacts
+    collectDiskFacts
+    collectMachineFacts
+
+    IFS='.' read -r installedMajorVersion installedMinorVersion installedPatchVersion <<< "${installedmacOSVersion}"
+    [[ -z "${installedMajorVersion}" || ! "${installedMajorVersion}" =~ ^[0-9]+$ ]] && installedMajorVersion="15"
+    [[ -z "${installedMinorVersion}" || ! "${installedMinorVersion}" =~ ^[0-9]+$ ]] && installedMinorVersion="0"
+    [[ -z "${installedPatchVersion}" || ! "${installedPatchVersion}" =~ ^[0-9]+$ ]] && installedPatchVersion="0"
+
+    ddmVersionString="${installedMajorVersion}.${installedMinorVersion}.$(( installedPatchVersion + 1 ))"
+    deadlineEpoch=$(date -v+7d +%s)
+    ddmEnforcedInstallDateEpoch="${deadlineEpoch}"
+    ddmVersionStringDaysRemaining="7"
+    ddmEnforcedInstallDateHumanReadable="$(formatDeadlineFromEpoch "${deadlineEpoch}" "${dateFormatDeadlineHumanReadable}")"
+    ddmEnforcedInstallDateRelativeHumanReadable="$(formatRelativeDeadlineHumanReadable "${deadlineEpoch}" "${ddmEnforcedInstallDateHumanReadable}")"
+    ddmVersionStringDeadlineHumanReadable="${ddmEnforcedInstallDateHumanReadable}"
+    versionComparisonResult="Update Required"
+    hideSecondaryButton="NO"
+    blurscreen="--noblurscreen"
+    updateOrUpgradeMode="update"
+    updateStagingStatus="Fully staged"
+
+    notice "Prepared demo runtime state: required macOS ${ddmVersionString}, deadline ${ddmEnforcedInstallDateHumanReadable}"
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Branding and Dialog Preparation
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function detectDarkMode() {
+    local interfaceStyle=""
+    local globalPreferencesPath="${loggedInUserHomeDirectory}/Library/Preferences/.GlobalPreferences.plist"
+
+    interfaceStyle=$(defaults read "${globalPreferencesPath}" AppleInterfaceStyle 2>/dev/null)
+    if [[ "${interfaceStyle}" == "Dark" ]]; then
+        echo "Dark"
+    else
+        echo "Light"
+    fi
+}
+
+function resolveDialogIconValue() {
+    local sourceValue="${1}"
+    local resolvedValue=""
+
+    if [[ -z "${sourceValue}" ]]; then
+        echo ""
+        return
+    fi
+
+    if [[ -e "${sourceValue}" ]]; then
+        resolvedValue="${sourceValue}"
+    elif [[ "${sourceValue}" =~ ^file:// ]]; then
+        resolvedValue="${sourceValue#file://}"
+        if [[ -e "${resolvedValue}" ]]; then
+            :
+        else
+            resolvedValue=""
+        fi
+    else
+        resolvedValue="${sourceValue}"
+    fi
+
+    echo "${resolvedValue}"
+}
+
+function downloadBrandingAssets() {
+    local appearanceMode="$(detectDarkMode)"
+    local overlayIconURL="${organizationOverlayiconURL}"
+    local majorDDM="${ddmVersionString%%.*}"
+
+    requestedAppearanceMode="${appearanceMode}"
+
+    if [[ "${appearanceMode}" == "Dark" && -n "${organizationOverlayiconURLdark}" ]]; then
+        notice "Dark mode detected; using dark mode overlay icon"
+        overlayIconURL="${organizationOverlayiconURLdark}"
+    else
+        notice "${appearanceMode} mode detected; using standard overlay icon"
+    fi
+
+    if [[ -n "${overlayIconURL}" ]]; then
+        overlayicon="$(resolveDialogIconValue "${overlayIconURL}")"
+        if [[ -n "${overlayicon}" ]]; then
+            info "Resolved overlay icon: ${overlayicon}"
+        else
+            warning "Could not resolve overlay icon from '${overlayIconURL}'; using Finder icon."
+            overlayicon="/System/Library/CoreServices/Finder.app"
+        fi
+    else
+        overlayicon="/System/Library/CoreServices/Finder.app"
+    fi
+
+    case "${majorDDM}" in
+        14) macOSIconURL="https://ics.services.jamfcloud.com/icon/hash_eecee9688d1bc0426083d427d80c9ad48fa118b71d8d4962061d4de8d45747e7" ;;
+        15) macOSIconURL="https://ics.services.jamfcloud.com/icon/hash_0968afcd54ff99edd98ec6d9a418a5ab0c851576b687756dc3004ec52bac704e" ;;
+        26) macOSIconURL="https://ics.services.jamfcloud.com/icon/hash_7320c100c9ca155dc388e143dbc05620907e2d17d6bf74a8fb6d6278ece2c2b4" ;;
+        *)  macOSIconURL="https://ics.services.jamfcloud.com/icon/hash_4555d9dc8fecb4e2678faffa8bdcf43cba110e81950e07a4ce3695ec2d5579ee" ;;
+    esac
+
+    icon="$(resolveDialogIconValue "${macOSIconURL}")"
+    [[ -z "${icon}" ]] && icon="/System/Library/CoreServices/Finder.app"
+
+    if [[ "${swapOverlayAndLogo}" == "YES" ]]; then
+        local tmp="${icon}"
+        icon="${overlayicon}"
+        overlayicon="${tmp}"
+        info "SwapOverlayAndLogo enabled; swapped primary and overlay icons."
+    fi
+
+    info "Using primary icon: ${icon}"
+}
+
+function computeDynamicWarnings() {
+    local allowedUptimeMinutes=$(( daysOfExcessiveUptimeWarning * 1440 ))
+    local belowThreshold=""
+
+    if (( upTimeMin < allowedUptimeMinutes )); then
+        excessiveUptimeWarningMessage=""
+    fi
+
+    if [[ "${freePercentage}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        belowThreshold=$(echo "${freePercentage} < ${minimumDiskFreePercentage}" | bc)
+        [[ "${belowThreshold}" -ne 1 ]] && diskSpaceWarningMessage=""
+    else
+        warning "freePercentage '${freePercentage}' is not numeric; suppressing disk-space warning."
+        diskSpaceWarningMessage=""
+    fi
+}
+
+function computeUpdateStagingMessage() {
+    if [[ "${hideStagedInfo}" == "YES" ]]; then
+        updateReadyMessage=""
+        return
+    fi
+
+    case "${updateStagingStatus}" in
+        "Fully staged")
+            updateReadyMessage="${stagedUpdateMessage}"
+            ;;
+        "Partially staged")
+            updateReadyMessage="${partiallyStagedUpdateMessage}"
+            ;;
+        "Pending download"|"Not detected")
+            updateReadyMessage="${pendingDownloadMessage}"
+            ;;
+        *)
+            updateReadyMessage=""
+            ;;
+    esac
+}
+
+function computeDeadlineEnforcementMessage() {
+    local markdownColorMinimumVersion="3.0.0.4928"
+    local deadlineDisplay="${ddmEnforcedInstallDateRelativeHumanReadable:-${ddmEnforcedInstallDateHumanReadable}}"
+    local baseDeadlineEnforcementMessage=""
+    local deadlineTemplateVariable="deadlineEnforcementMessageAbsolute"
+
+    if [[ "${deadlineDisplay}" != "${ddmEnforcedInstallDateHumanReadable}" ]]; then
+        deadlineTemplateVariable="deadlineEnforcementMessageRelative"
+    fi
+
+    baseDeadlineEnforcementMessage="${(P)deadlineTemplateVariable}"
+    baseDeadlineEnforcementMessage=${baseDeadlineEnforcementMessage//\{deadlineDisplay\}/${deadlineDisplay}}
+    baseDeadlineEnforcementMessage=${baseDeadlineEnforcementMessage//\{titleMessageUpdateOrUpgrade:l\}/${titleMessageUpdateOrUpgrade:l}}
+    baseDeadlineEnforcementMessage=${baseDeadlineEnforcementMessage//\{titleMessageUpdateOrUpgrade\}/${titleMessageUpdateOrUpgrade}}
+
+    dialogVersion="$(${dialogBinary} -v 2>/dev/null)"
+
+    if [[ -n "${dialogVersion}" ]] && is-at-least "${markdownColorMinimumVersion}" "${dialogVersion}"; then
+        dialogSupportsMarkdownColor="YES"
+        deadlineEnforcementMessage=":red[${baseDeadlineEnforcementMessage}]"
+    else
+        dialogSupportsMarkdownColor="NO"
+        deadlineEnforcementMessage="${baseDeadlineEnforcementMessage}"
+    fi
+}
+
+function computeInfoboxHighlights() {
+    infoboxDeadlineDisplay="${ddmVersionStringDeadlineHumanReadable}"
+    infoboxDaysRemainingDisplay="${ddmVersionStringDaysRemaining}"
+    infoboxLastRestartDisplay="${uptimeHumanReadable}"
+
+    if [[ "${dialogSupportsMarkdownColor}" != "YES" ]]; then
+        return
+    fi
+
+    if (( upTimeMin >= (daysOfExcessiveUptimeWarning * 1440) )); then
+        infoboxLastRestartDisplay=":red[${infoboxLastRestartDisplay}]"
+    fi
+}
+
+function buildPlaceholderMap() {
+    declare -gA PLACEHOLDER_MAP=(
+        [weekday]="$(localizedWeekdayName "${dialogLanguage}")"
+        [userfirstname]="${loggedInUserFirstname}"
+        [loggedInUserFirstname]="${loggedInUserFirstname}"
+        [userfullname]="${userfullname}"
+        [username]="${username}"
+        [computername]="${computername}"
+        [serialnumber]="${serialnumber}"
+        [osversion]="${osversion}"
+        [ddmVersionString]="${ddmVersionString}"
+        [ddmEnforcedInstallDateHumanReadable]="${ddmEnforcedInstallDateHumanReadable}"
+        [ddmEnforcedInstallDateRelativeHumanReadable]="${ddmEnforcedInstallDateRelativeHumanReadable}"
+        [installedmacOSVersion]="${installedmacOSVersion}"
+        [ddmVersionStringDeadlineHumanReadable]="${ddmVersionStringDeadlineHumanReadable}"
+        [ddmVersionStringDaysRemaining]="${ddmVersionStringDaysRemaining}"
+        [infoboxDeadlineDisplay]="${infoboxDeadlineDisplay}"
+        [infoboxDaysRemainingDisplay]="${infoboxDaysRemainingDisplay}"
+        [infoboxLastRestartDisplay]="${infoboxLastRestartDisplay}"
+        [titleMessageUpdateOrUpgrade]="${titleMessageUpdateOrUpgrade}"
+        [uptimeHumanReadable]="${uptimeHumanReadable}"
+        [excessiveUptimeWarningMessage]="${excessiveUptimeWarningMessage}"
+        [updateReadyMessage]="${updateReadyMessage}"
+        [diskSpaceHumanReadable]="${diskSpaceHumanReadable}"
+        [diskSpaceWarningMessage]="${diskSpaceWarningMessage}"
+        [softwareUpdateButtonText]="${softwareUpdateButtonText}"
+        [infoboxLabelCurrent]="${infoboxLabelCurrent}"
+        [infoboxLabelRequired]="${infoboxLabelRequired}"
+        [infoboxLabelDeadline]="${infoboxLabelDeadline}"
+        [infoboxLabelDaysRemaining]="${infoboxLabelDaysRemaining}"
+        [infoboxLabelLastRestart]="${infoboxLabelLastRestart}"
+        [infoboxLabelFreeDiskSpace]="${infoboxLabelFreeDiskSpace}"
+        [deadlineEnforcementMessage]="${deadlineEnforcementMessage}"
+        [button1text]="${button1text}"
+        [button2text]="${button2text}"
+        [supportTeamName]="${supportTeamName}"
+        [supportTeamPhone]="${supportTeamPhone}"
+        [supportTeamEmail]="${supportTeamEmail}"
+        [supportTeamWebsite]="${supportTeamWebsite}"
+        [supportKBURL]="${supportKBURL}"
+        [supportKB]="${supportKB}"
+        [supportAssistanceMessage]="${supportAssistanceMessage}"
+        [infobuttonaction]="${infobuttonaction}"
+        [dialogVersion]="${dialogVersion}"
+        [scriptVersion]="${scriptVersion}"
+    )
+}
+
+function replacePlaceholders() {
+    local targetVariable="${1}"
+    local value="${(P)targetVariable}"
+    local previousValue=""
+    local maxPasses=5
+    local pass=0
+
+    while (( pass < maxPasses )); do
+        previousValue="${value}"
+
+        for placeholder replaceValue in "${(@kv)PLACEHOLDER_MAP}"; do
+            value=${value//\{${placeholder}\}/${replaceValue}}
+            value=${value//\{${placeholder}:l\}/${replaceValue:l}}
+        done
+
+        (( pass++ ))
+        [[ "${value}" == "${previousValue}" ]] && break
+    done
+
+    printf -v "${targetVariable}" '%s' "${value}"
+}
+
+function applyHideRules() {
+    case "${infobuttontext}" in
+        "hide")
+            infobuttontext=""
+            ;;
+    esac
+
+    case "${helpimage}" in
+        "hide")
+            helpimage=""
+            ;;
+    esac
+
+    case "${hideSecondaryButton}" in
+        "YES")
+            button2text=""
+            ;;
+    esac
+}
+
+function updateRequiredVariables() {
+    dialogBinary="/usr/local/bin/dialog"
+    [[ ! -x "${dialogBinary}" ]] && fatal "swiftDialog not found at '${dialogBinary}'."
+
+    action="x-apple.systempreferences:com.apple.preferences.softwareupdate"
+    downloadBrandingAssets
+    applyLocalizedDialogText
+    applyLocalizedUpdateVocabulary
+    computeDynamicWarnings
+    computeUpdateStagingMessage
+    computeDeadlineEnforcementMessage
+    computeInfoboxHighlights
+
+    if [[ "${infobuttontext}" == "hide" ]]; then
+        supportAssistanceMessage=""
+    fi
+
+    buildPlaceholderMap
+
+    local textFields=(
+        "title" "button1text" "button2text" "infobuttontext"
+        "infobox" "helpmessage" "helpimage"
+        "excessiveUptimeWarningMessage" "diskSpaceWarningMessage"
+        "message" "supportAssistanceMessage"
+    )
+
+    for field in "${textFields[@]}"; do
+        replacePlaceholders "${field}"
+    done
+
+    applyHideRules
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Debug Output
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function printResolvedPreferenceSummary() {
+    preFlight "Preference domain: ${preferenceDomain}"
+    preFlight "Managed preferences: ${managedPreferencesPlist}.plist (${foundManagedPreferences})"
+    preFlight "Local preferences: ${localPreferencesPlist}.plist (${foundLocalPreferences})"
+    preFlight "Resolved language: ${dialogLanguage}"
+    preFlight "Detected appearance: ${requestedAppearanceMode}"
+    preFlight "Title: ${title}"
+    preFlight "Primary button: ${button1text}"
+    preFlight "Secondary button: ${button2text:-<hidden>}"
+    preFlight "Info button: ${infobuttontext:-<hidden>}"
+    preFlight "Overlay icon source: ${overlayicon}"
+    preFlight "Main icon source: ${icon}"
+    preFlight "Help image: ${helpimage}"
+    preFlight "Infobox: ${infobox}"
+    preFlight "Message: ${message}"
+}
+
+function printDialogArguments() {
+    local arg=""
+
+    preFlight "swiftDialog arguments:"
+    for arg in "${dialogArgs[@]}"; do
+        echo "  ${arg}"
+    done
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Button Actions
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function openDialogAction() {
+    local targetAction="${1}"
+    local actionLabel="${2}"
+
+    if [[ -z "${targetAction}" ]]; then
+        warning "No action configured for '${actionLabel}'."
+        return 1
+    fi
+
+    if open "${targetAction}"; then
+        info "Opened ${actionLabel}: ${targetAction}"
+        return 0
+    fi
+
+    warning "Failed to open ${actionLabel}: ${targetAction}"
+    return 1
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Display Reminder Dialog
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function displayReminderDialog() {
+    dialogArgs=(
+        --title "${title}"
+        --message "${message}"
+        --icon "${icon}"
+        --iconsize 250
+        --overlayicon "${overlayicon}"
+        --infobox "${infobox}"
+        --button1text "${button1text}"
+        --messagefont "size=14"
+        --quitkey "k"
+        --width 800
+        --height 650
+        "${blurscreen}"
+    )
+
+    [[ -n "${button2text}" ]] && dialogArgs+=(--button2text "${button2text}")
+    [[ "${hideSecondaryButton}" == "DISABLED" ]] && dialogArgs+=(--button2disabled)
+    [[ -n "${infobuttontext}" ]] && dialogArgs+=(--infobuttontext "${infobuttontext}")
+    [[ -n "${helpmessage}" ]] && dialogArgs+=(--helpmessage "${helpmessage}")
+    [[ -n "${helpimage}" ]] && dialogArgs+=(--helpimage "${helpimage}")
+
+    printDialogArguments
+
+    "${dialogBinary}" "${dialogArgs[@]}"
+    returncode=$?
+    info "swiftDialog return code: ${returncode}"
+
+    case ${returncode} in
+        0)
+            notice "${loggedInUser} clicked ${button1text}"
+            openDialogAction "${action}" "System Settings Software Update pane"
+            ;;
+        2)
+            notice "${loggedInUser} clicked ${button2text}"
+            info "Preview dismissed via secondary button."
+            ;;
+        3)
+            notice "${loggedInUser} clicked ${infobuttontext}"
+            openDialogAction "${infobuttonaction}" "${infobuttontext:-Info button action}"
+            ;;
+        *)
+            info "No post-dialog action for return code ${returncode}."
+            ;;
+    esac
+}
+
+
+
+####################################################################################################
+#
+# Program
+#
+####################################################################################################
+
+preFlight "\n\n###\n# ${humanReadableScriptName} (${scriptVersion})\n# http://snelson.us/ddm\n###\n"
+preFlight "Initiating …"
+
+if ! loadPreferenceOverrides; then
+    echo
+    echo "No managed or local preferences were found for '${preferenceDomain}'."
+    echo
+    echo "Expected one of:"
+    echo "  ${managedPreferencesPlist}.plist"
+    echo "  ${localPreferencesPlist}.plist"
+    echo
+    echo "Install your Configuration Profile or local plist, then re-run:"
+    echo "  zsh Resources/reminderDialogPreferenceTest.zsh"
+    echo
+    echo "Alternatively, you can copy the 'sample.plist' to the appropriate location:"
+    echo "  cp -v Resources/sample.plist /Library/Preferences/org.churchofjesuschrist.dorm.plist"
+    echo "  zsh Resources/reminderDialogPreferenceTest.zsh"
+    echo
+    echo
+    exit 0
+fi
+
+resolveEffectiveUserContext
+resolveDialogLanguage
+initializeLocalizedRuntimeFields
+prepareDemoRuntimeState
+
+# -------------------------------------------------------------------------
+# Real dialog-display logic begins here; all DDM enforcement logic is
+# intentionally omitted in this preview script.
+# -------------------------------------------------------------------------
+
+updateRequiredVariables
+printResolvedPreferenceSummary
+displayReminderDialog
+
+exit 0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+Thank you for helping keep **DDM OS Reminder** secure.
+
+DDM OS Reminder is a macOS-only project commonly deployed through MDM, runs with **`root` privileges**, reads **`/var/log/install.log`**, deploys a LaunchDaemon plus reminder script, can auto-download and install **swiftDialog**, writes operational logs, and generates deployable **plist** and **mobileconfig** artifacts. The maintained attack surface includes the main runtime and deployment scripts, helper content under **`Resources/`**, and tracked deployment artifacts committed under **`Artifacts/`**.
+
+## Supported Versions
+
+The latest stable release and the current prerelease line are actively supported for security updates.
+
+- Current stable: **v3.1.0**
+- Current prerelease line: **v3.1.0b\***
+- Older releases receive no security patches.
+
+If you are running an older release, upgrade before requesting security support.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, report it privately.
+
+**Do not** open a public GitHub Issue or Pull Request that discloses the vulnerability.
+
+Send reports to: **security@snelson.us**
+
+Please include as much of the following as possible:
+
+- A clear description of the issue and its potential impact
+- Steps to reproduce it
+- Affected version(s) of DDM OS Reminder
+- Deployment context, such as MDM platform, LaunchDaemon behavior, or managed preference configuration
+- Relevant logs, screenshots, or proof-of-concept details
+- Any suggested mitigation or fix
+- Your name or handle, if you want attribution
+
+You should receive an acknowledgment within **48 hours**. We will work with you to validate the report, develop a fix, and coordinate disclosure once the issue is resolved.
+
+## Safe Use Guidance
+
+- Test changes and deployments in a lab or VM before broad rollout.
+- Use trusted distribution paths, such as official GitHub releases or your own signed packaging flow.
+- Review organization-specific customizations before deployment, especially branding, support links, restart policy, and user-facing dialog text.
+- Validate managed preferences, local overrides, and **RDNN** consistency before production use.
+- Review generated LaunchDaemon, plist, and unsigned mobileconfig artifacts before promotion into production workflows.
+
+## Code Security Practices
+
+- This repository is scanned with **Semgrep** using the `p/r2c-security-audit`, `p/ci`, and `p/secrets` rulesets.
+- **Gitleaks** scans repository history for potential credential or secret exposure.
+- Tracked `*.zsh` files and zsh-shebang helpers are validated with **`zsh -n`**, including the main entrypoints, zsh helpers under `Resources/`, and tracked assembled zsh artifacts under `Artifacts/`.
+- Tracked `*.sh` and `*.bash` files are checked with **ShellCheck** when present.
+- Changes are reviewed with attention to shell quoting, install-log parsing, download and install paths, LaunchDaemon deployment, plist/mobileconfig generation, and preference handling.
+- The current deployment script validates downloaded swiftDialog installers with **Team ID** verification before installation.
+
+## Disclosure Policy
+
+- We follow coordinated disclosure.
+- We will prioritize a fix before sharing public technical details.
+- Security fixes will be released as quickly as practical, typically with a tagged release and changelog note.
+- We will credit the reporter unless anonymity is requested.
+
+## General Security Questions
+
+For non-vulnerability questions or general usage concerns, use the public project channels.
+
+Community-supplied, best-effort support is available on the [Mac Admins Slack](https://www.macadmins.org) (free, registration required) [#ddm-os-reminders](https://slack.com/app_redirect?channel=C09LVE2NVML) channel, or you can open an issue on [GitHub](https://github.com/dan-snelson/DDM-OS-Reminder/issues).
+
+Last updated: April 2026

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,7 @@ You should receive an acknowledgment within **48 hours**. We will work with you 
 - This repository is scanned with **Semgrep** using the `p/r2c-security-audit`, `p/ci`, and `p/secrets` rulesets.
 - **Gitleaks** scans repository history for potential credential or secret exposure.
 - Tracked `*.zsh` files and zsh-shebang helpers are validated with **`zsh -n`**, including the main entrypoints, zsh helpers under `Resources/`, and tracked assembled zsh artifacts under `Artifacts/`.
-- Tracked `*.sh` and `*.bash` files are checked with **ShellCheck** when present.
+- Tracked shell-script files with `bash`, `dash`, `ksh`, or `sh` shebangs are checked with **ShellCheck** when present.
 - Changes are reviewed with attention to shell quoting, install-log parsing, download and install paths, LaunchDaemon deployment, plist/mobileconfig generation, and preference handling.
 - The current deployment script validates downloaded swiftDialog installers with **Team ID** verification before installation.
 


### PR DESCRIPTION
## Summary
Add a repo-specific GitHub Actions security scan workflow and a tailored SECURITY.md policy.

## What Changed
- add `.github/workflows/security-scan.yml`
- add `SECURITY.md`
- classify scan targets by actual shebang so zsh files go through `zsh -n` and sh/bash files go through ShellCheck
- fix external check scripts that were failing the new ShellCheck gate

## Validation
- parsed `.github/workflows/security-scan.yml` successfully
- ran `zsh -n` on zsh and zsh-shebang targets
- ran ShellCheck on sh/bash-shebang targets
- confirmed the GitHub Actions security scan passed

## Notes
- PR target is `development` per repo contribution guidance