### PR TITLE
Change German localization for 'Aktualisierung' to 'Update'

### DIFF
--- a/Resources/sample.plist
+++ b/Resources/sample.plist
@@ -502,7 +502,7 @@
     <key>DeadlineEnforcementMessageAbsoluteLocalized_en</key>
     <string>However, your Mac **will automatically restart and {titleMessageUpdateOrUpgrade:l}** on **{deadlineDisplay}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline.</string>
     <key>DeadlineEnforcementMessageAbsoluteLocalized_de</key>
-    <string>Andernfalls **wird dein Mac am {deadlineDisplay} automatisch neu gestartet, um das erforderliche macOS-{titleMessageUpdateOrUpgrade:l} zu installieren**.</string>
+    <string>Andernfalls **wird dein Mac am {deadlineDisplay} automatisch neu gestartet, um das erforderliche macOS-{titleMessageUpdateOrUpgrade} zu installieren**.</string>
     <key>DeadlineEnforcementMessageAbsoluteLocalized_fr</key>
     <string>Sinon, votre Mac **redémarrera automatiquement et appliquera la {titleMessageUpdateOrUpgrade:l}** le **{deadlineDisplay}**.</string>
     <key>DeadlineEnforcementMessageAbsoluteLocalized_es</key>
@@ -520,7 +520,7 @@
     <key>DeadlineEnforcementMessageRelativeLocalized_en</key>
     <string>However, your Mac **will automatically restart and {titleMessageUpdateOrUpgrade:l}** **{deadlineDisplay}** if you have not {titleMessageUpdateOrUpgrade:l}d before the deadline.</string>
     <key>DeadlineEnforcementMessageRelativeLocalized_de</key>
-    <string>Andernfalls **wird dein Mac {deadlineDisplay} automatisch neu gestartet, um das erforderliche macOS-{titleMessageUpdateOrUpgrade:l} zu installieren**.</string>
+    <string>Andernfalls **wird dein Mac {deadlineDisplay} automatisch neu gestartet, um das erforderliche macOS-{titleMessageUpdateOrUpgrade} zu installieren**.</string>
     <key>DeadlineEnforcementMessageRelativeLocalized_fr</key>
     <string>Sinon, votre Mac **redémarrera automatiquement et appliquera la {titleMessageUpdateOrUpgrade:l}** **{deadlineDisplay}**.</string>
     <key>DeadlineEnforcementMessageRelativeLocalized_es</key>

--- a/Resources/sample.plist
+++ b/Resources/sample.plist
@@ -304,7 +304,7 @@
     <key>UpdateWordLocalized_en</key>
     <string>Update</string>
     <key>UpdateWordLocalized_de</key>
-    <string>Aktualisierung</string>
+    <string>Update</string>
     <key>UpdateWordLocalized_fr</key>
     <string>Mise à jour</string>
     <key>UpdateWordLocalized_es</key>


### PR DESCRIPTION
Translating "update" as "Aktualisierung" makes no sense in the context of the text. "Update" fits and is commonly used.